### PR TITLE
Improve EAGLE loader handling

### DIFF
--- a/bench/chat.py
+++ b/bench/chat.py
@@ -7,10 +7,12 @@ Usage:
     python chat.py --vllm [--ar]
     python chat.py --sglang --url http://localhost:40010
 """
+
 import os, sys, time, json, signal, argparse, subprocess, multiprocessing as mp
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import HF_CACHE_DIR, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 TARGET = resolve_snapshot(f"{HF_CACHE_DIR}/models--meta-llama--Llama-3.1-70B-Instruct")
 DRAFT = resolve_snapshot(f"{HF_CACHE_DIR}/models--meta-llama--Llama-3.2-1B-Instruct")
@@ -35,8 +37,16 @@ def parse_args():
     p.add_argument("--b", type=int, default=1)
     p.add_argument("--x", type=float, default=None)
     p.add_argument("--eager", action="store_true")
-    p.add_argument("--ignore_eos", action="store_true", help="Ignore EOS token (generate full output_len)")
-    p.add_argument("--metrics", action="store_true", help="Print token count, speed, TTFT after each response")
+    p.add_argument(
+        "--ignore_eos",
+        action="store_true",
+        help="Ignore EOS token (generate full output_len)",
+    )
+    p.add_argument(
+        "--metrics",
+        action="store_true",
+        help="Print token count, speed, TTFT after each response",
+    )
     # Server
     p.add_argument("--tp", type=int, default=4)
     p.add_argument("--port", type=int, default=None)
@@ -53,7 +63,7 @@ def _decode_worker(conn, tokenizer):
             break
         ids.extend(chunk)
         full = tokenizer.decode(ids, skip_special_tokens=True)
-        delta = full[len(prev):]
+        delta = full[len(prev) :]
         if delta:
             print(delta, end="", flush=True)
         prev = full
@@ -66,12 +76,21 @@ def ssd_chat(args):
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
     tokenizer = AutoTokenizer.from_pretrained(TARGET)
-    llm = LLM(TARGET, enforce_eager=args.eager, num_gpus=args.gpus,
-              speculate=args.spec, speculate_k=args.k,
-              draft_async=args.async_spec, async_fan_out=args.f,
-              draft=DRAFT, kvcache_block_size=256, max_num_seqs=args.b,
-              max_model_len=8192, sampler_x=args.x,
-              jit_speculate=(args.backup == "jit"))
+    llm = LLM(
+        TARGET,
+        enforce_eager=args.eager,
+        num_gpus=args.gpus,
+        speculate=args.spec,
+        speculate_k=args.k,
+        draft_async=args.async_spec,
+        async_fan_out=args.f,
+        draft=DRAFT,
+        kvcache_block_size=256,
+        max_num_seqs=args.b,
+        max_model_len=8192,
+        sampler_x=args.x,
+        jit_speculate=(args.backup == "jit"),
+    )
 
     history = []
     print(f"\nChat via SSD. Type 'quit' to exit.\n")
@@ -79,27 +98,40 @@ def ssd_chat(args):
         try:
             user_input = input("User: ")
         except (EOFError, KeyboardInterrupt):
-            print(); break
+            print()
+            break
         if user_input.strip().lower() in ("quit", "exit", "q"):
             break
 
         history.append({"role": "user", "content": user_input})
-        token_ids = tokenizer.apply_chat_template(history, add_generation_prompt=True, tokenize=True)
-        sp = SamplingParams(temperature=args.temp, max_new_tokens=args.output_len, ignore_eos=args.ignore_eos)
+        token_ids = tokenizer.apply_chat_template(
+            history, add_generation_prompt=True, tokenize=True
+        )
+        sp = SamplingParams(
+            temperature=args.temp,
+            max_new_tokens=args.output_len,
+            ignore_eos=args.ignore_eos,
+        )
 
         parent_conn, child_conn = mp.Pipe()
-        proc = mp.Process(target=_decode_worker, args=(child_conn, tokenizer), daemon=True)
+        proc = mp.Process(
+            target=_decode_worker, args=(child_conn, tokenizer), daemon=True
+        )
         proc.start()
         child_conn.close()
 
         t_first = [None]
+
         def on_tokens(seq_id, new_ids):
-            if t_first[0] is None: t_first[0] = time.time()
+            if t_first[0] is None:
+                t_first[0] = time.time()
             parent_conn.send(list(new_ids))
 
         print("Assistant: ", end="", flush=True)
         t0 = time.time()
-        outputs, _ = llm.generate([token_ids], [sp], use_tqdm=False, stream_callback=on_tokens)
+        outputs, _ = llm.generate(
+            [token_ids], [sp], use_tqdm=False, stream_callback=on_tokens
+        )
         t_end = time.time()
         parent_conn.send(None)
         proc.join(timeout=5)
@@ -108,17 +140,21 @@ def ssd_chat(args):
         ttft = (t_first[0] - t0) if t_first[0] else 0
         dt = t_end - (t_first[0] or t0)
         if args.metrics:
-            print(f"\n  [{n} tok, {n/dt:.0f} tok/s, {ttft:.2f}s TTFT]")
+            print(f"\n  [{n} tok, {n / dt:.0f} tok/s, {ttft:.2f}s TTFT]")
         print()
         history.append({"role": "assistant", "content": outputs[0]["text"]})
 
 
 def wait_for_server(port, timeout=900, interval=5):
     import requests
+
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            if requests.get(f"http://localhost:{port}/health", timeout=2).status_code == 200:
+            if (
+                requests.get(f"http://localhost:{port}/health", timeout=2).status_code
+                == 200
+            ):
                 return True
         except (requests.ConnectionError, requests.Timeout):
             pass
@@ -129,6 +165,7 @@ def wait_for_server(port, timeout=900, interval=5):
 def server_chat(args):
     import requests
     from transformers import AutoTokenizer
+
     tokenizer = AutoTokenizer.from_pretrained(TARGET)
 
     backend = "sglang" if args.sglang else "vllm"
@@ -139,34 +176,74 @@ def server_chat(args):
         base_url = args.url.rstrip("/")
     else:
         if args.sglang:
-            cmd = [sys.executable, "-m", "sglang.launch_server",
-                   "--model-path", TARGET, "--tp", str(args.tp),
-                   "--mem-fraction-static", "0.70", "--max-running-requests", "1",
-                   "--disable-radix-cache", "--log-level", "warning",
-                   "--port", str(port)]
+            cmd = [
+                sys.executable,
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                TARGET,
+                "--tp",
+                str(args.tp),
+                "--mem-fraction-static",
+                "0.70",
+                "--max-running-requests",
+                "1",
+                "--disable-radix-cache",
+                "--log-level",
+                "warning",
+                "--port",
+                str(port),
+            ]
             if not args.ar:
-                cmd += ["--speculative-algorithm", "STANDALONE",
-                        "--speculative-draft-model-path", DRAFT,
-                        "--speculative-num-steps", "4",
-                        "--speculative-eagle-topk", "1",
-                        "--speculative-num-draft-tokens", "5"]
+                cmd += [
+                    "--speculative-algorithm",
+                    "STANDALONE",
+                    "--speculative-draft-model-path",
+                    DRAFT,
+                    "--speculative-num-steps",
+                    "4",
+                    "--speculative-eagle-topk",
+                    "1",
+                    "--speculative-num-draft-tokens",
+                    "5",
+                ]
         else:
-            cmd = [sys.executable, "-m", "vllm.entrypoints.openai.api_server",
-                   "--model", TARGET, "--tensor-parallel-size", str(args.tp),
-                   "--gpu-memory-utilization", "0.90", "--max-num-seqs", "1",
-                   "--disable-log-requests", "--disable-log-stats", "--port", str(port)]
+            cmd = [
+                sys.executable,
+                "-m",
+                "vllm.entrypoints.openai.api_server",
+                "--model",
+                TARGET,
+                "--tensor-parallel-size",
+                str(args.tp),
+                "--gpu-memory-utilization",
+                "0.90",
+                "--max-num-seqs",
+                "1",
+                "--disable-log-requests",
+                "--disable-log-stats",
+                "--port",
+                str(port),
+            ]
             if not args.ar:
-                spec = {"model": DRAFT, "num_speculative_tokens": 5, "method": "draft_model"}
+                spec = {
+                    "model": DRAFT,
+                    "num_speculative_tokens": 5,
+                    "method": "draft_model",
+                }
                 cmd += ["--speculative-config", json.dumps(spec)]
 
-        subprocess.run(["pkill", "-9", "-f",
-                        "sglang.launch_server" if args.sglang else "vllm.entrypoints"],
-                       capture_output=True)
-        time.sleep(2)
+        ensure_port_available(port, backend)
         print(f"Launching {backend}...")
-        proc = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        proc = subprocess.Popen(
+            cmd,
+            preexec_fn=os.setsid,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         if not wait_for_server(port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Ready.")
         base_url = f"http://localhost:{port}"
 
@@ -178,40 +255,56 @@ def server_chat(args):
             try:
                 user_input = input("User: ")
             except (EOFError, KeyboardInterrupt):
-                print(); break
+                print()
+                break
             if user_input.strip().lower() in ("quit", "exit", "q"):
                 break
 
             history.append({"role": "user", "content": user_input})
-            token_ids = tokenizer.apply_chat_template(history, add_generation_prompt=True, tokenize=True)
-            payload = {"model": TARGET, "prompt": token_ids,
-                       "temperature": args.temp, "max_tokens": args.output_len,
-                       "stream": True, "stream_options": {"include_usage": True}}
+            token_ids = tokenizer.apply_chat_template(
+                history, add_generation_prompt=True, tokenize=True
+            )
+            payload = {
+                "model": TARGET,
+                "prompt": token_ids,
+                "temperature": args.temp,
+                "max_tokens": args.output_len,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
 
             print("Assistant: ", end="", flush=True)
             t0 = time.time()
-            resp = requests.post(f"{base_url}/v1/completions", json=payload, stream=True)
+            resp = requests.post(
+                f"{base_url}/v1/completions", json=payload, stream=True
+            )
             resp.raise_for_status()
 
             full, t_first, usage = "", None, {}
             for line in resp.iter_lines(decode_unicode=True):
-                if not line or not line.startswith("data: "): continue
+                if not line or not line.startswith("data: "):
+                    continue
                 data = line[6:]
-                if data.strip() == "[DONE]": break
+                if data.strip() == "[DONE]":
+                    break
                 chunk = json.loads(data)
-                delta = chunk["choices"][0].get("text", "") if chunk.get("choices") else ""
+                delta = (
+                    chunk["choices"][0].get("text", "") if chunk.get("choices") else ""
+                )
                 if delta:
-                    if t_first is None: t_first = time.time()
+                    if t_first is None:
+                        t_first = time.time()
                     full += delta
                     print(delta, end="", flush=True)
-                if "usage" in chunk: usage = chunk["usage"]
+                if "usage" in chunk:
+                    usage = chunk["usage"]
 
             t_end = time.time()
             n = usage.get("completion_tokens", len(full.split()))
             ttft = (t_first - t0) if t_first else 0
             dt = t_end - (t_first or t0)
             if args.metrics:
-                print(f"\n  [{n} tok, {n/dt:.0f} tok/s, {ttft:.2f}s TTFT]")
+                print(f"\n  [{n} tok, {n / dt:.0f} tok/s, {ttft:.2f}s TTFT]")
             print()
             history.append({"role": "assistant", "content": full})
     finally:

--- a/bench/run_sglang_bench.py
+++ b/bench/run_sglang_bench.py
@@ -11,6 +11,7 @@ Usage:
 
 Set model paths via env vars (BENCH_LLAMA_70B, etc.) or edit bench_paths.py.
 """
+
 import os
 import sys
 import time
@@ -21,6 +22,7 @@ import requests
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import MODELS, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 
 def get_server_cmd(args):
@@ -32,25 +34,38 @@ def get_server_cmd(args):
         draft = resolve_snapshot(MODELS["qwen_0.6b"])
 
     cmd = [
-        sys.executable, "-m", "sglang.launch_server",
-        "--model-path", target,
-        "--tp", str(args.tp),
-        "--mem-fraction-static", str(args.mem_frac),
-        "--max-running-requests", "1",
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        target,
+        "--tp",
+        str(args.tp),
+        "--mem-fraction-static",
+        str(args.mem_frac),
+        "--max-running-requests",
+        "1",
         "--disable-radix-cache",
-        "--log-level", "warning",
-        "--port", str(args.port),
+        "--log-level",
+        "warning",
+        "--port",
+        str(args.port),
     ]
 
     if args.mode == "sd":
         # Speculative decoding with standalone draft model.
         # Default: k=5 (num_steps=4, num_draft_tokens=5).
         cmd += [
-            "--speculative-algorithm", "STANDALONE",
-            "--speculative-draft-model-path", draft,
-            "--speculative-num-steps", str(args.num_steps),
-            "--speculative-eagle-topk", "1",
-            "--speculative-num-draft-tokens", str(args.num_draft_tokens),
+            "--speculative-algorithm",
+            "STANDALONE",
+            "--speculative-draft-model-path",
+            draft,
+            "--speculative-num-steps",
+            str(args.num_steps),
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            str(args.num_draft_tokens),
         ]
     # mode == "ar": no speculative flags, just serve the target model.
 
@@ -77,15 +92,23 @@ def kill_server(proc):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Launch SGLang server and benchmark it")
+    parser = argparse.ArgumentParser(
+        description="Launch SGLang server and benchmark it"
+    )
     parser.add_argument("--llama", action="store_true", default=True)
     parser.add_argument("--qwen", action="store_true")
-    parser.add_argument("--mode", choices=["ar", "sd"], default="sd",
-                        help="ar = autoregressive, sd = speculative decoding (default)")
+    parser.add_argument(
+        "--mode",
+        choices=["ar", "sd"],
+        default="sd",
+        help="ar = autoregressive, sd = speculative decoding (default)",
+    )
     parser.add_argument("--tp", type=int, default=4)
     parser.add_argument("--port", type=int, default=40010)
     parser.add_argument("--mem_frac", type=float, default=0.70)
-    parser.add_argument("--num_steps", type=int, default=4, help="draft chain depth (k = num_steps + 1)")
+    parser.add_argument(
+        "--num_steps", type=int, default=4, help="draft chain depth (k = num_steps + 1)"
+    )
     parser.add_argument("--num_draft_tokens", type=int, default=5)
     # Pass-through to eval client
     parser.add_argument("--numseqs", type=int, default=128)
@@ -102,28 +125,34 @@ def main():
     print(f"Mode: {args.mode}, Target: {target}")
     print(f"Server cmd: {' '.join(server_cmd)}")
 
-    # Kill stale sglang processes
-    subprocess.run(["pkill", "-9", "-f", "sglang.launch_server"],
-                   capture_output=True)
-    time.sleep(2)
+    ensure_port_available(args.port, "SGLang")
 
     proc = subprocess.Popen(server_cmd, preexec_fn=os.setsid)
     try:
         print("Waiting for server...")
         if not wait_for_server(args.port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Server ready")
 
         # Build eval client command
         bench_dir = os.path.dirname(__file__)
         eval_cmd = [
-            sys.executable, os.path.join(bench_dir, "sglang_eval_client.py"),
-            "--size", "70" if args.llama else "32",
-            "--numseqs", str(args.numseqs),
-            "--output_len", str(args.output_len),
-            "--temp", str(args.temp),
-            "--all", "--b", "1",
-            "--port", str(args.port),
+            sys.executable,
+            os.path.join(bench_dir, "sglang_eval_client.py"),
+            "--size",
+            "70" if args.llama else "32",
+            "--numseqs",
+            str(args.numseqs),
+            "--output_len",
+            str(args.output_len),
+            "--temp",
+            str(args.temp),
+            "--all",
+            "--b",
+            "1",
+            "--port",
+            str(args.port),
         ]
         if args.llama:
             eval_cmd.append("--llama")

--- a/bench/run_vllm_bench.py
+++ b/bench/run_vllm_bench.py
@@ -11,6 +11,7 @@ Usage:
 
 Set model paths via env vars (BENCH_LLAMA_70B, etc.) or edit bench_paths.py.
 """
+
 import os
 import sys
 import json
@@ -22,6 +23,7 @@ import requests
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import MODELS, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 
 def get_server_cmd(args):
@@ -33,13 +35,20 @@ def get_server_cmd(args):
         draft = resolve_snapshot(MODELS["qwen_0.6b"])
 
     cmd = [
-        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
-        "--model", target,
-        "--tensor-parallel-size", str(args.tp),
-        "--gpu-memory-utilization", str(args.mem_frac),
-        "--max-num-seqs", "1",
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        target,
+        "--tensor-parallel-size",
+        str(args.tp),
+        "--gpu-memory-utilization",
+        str(args.mem_frac),
+        "--max-num-seqs",
+        "1",
         "--disable-log-requests",
-        "--port", str(args.port),
+        "--port",
+        str(args.port),
     ]
 
     if args.mode == "sd":
@@ -78,8 +87,12 @@ def main():
     parser = argparse.ArgumentParser(description="Launch vLLM server and benchmark it")
     parser.add_argument("--llama", action="store_true", default=True)
     parser.add_argument("--qwen", action="store_true")
-    parser.add_argument("--mode", choices=["ar", "sd"], default="sd",
-                        help="ar = autoregressive, sd = speculative decoding (default)")
+    parser.add_argument(
+        "--mode",
+        choices=["ar", "sd"],
+        default="sd",
+        help="ar = autoregressive, sd = speculative decoding (default)",
+    )
     parser.add_argument("--tp", type=int, default=4)
     parser.add_argument("--port", type=int, default=40020)
     parser.add_argument("--mem_frac", type=float, default=0.90)
@@ -99,27 +112,33 @@ def main():
     print(f"Mode: {args.mode}, Target: {target}")
     print(f"Server cmd: {' '.join(server_cmd)}")
 
-    # Kill stale vllm processes
-    subprocess.run(["pkill", "-9", "-f", "vllm.entrypoints"],
-                   capture_output=True)
-    time.sleep(2)
+    ensure_port_available(args.port, "vLLM")
 
     proc = subprocess.Popen(server_cmd, preexec_fn=os.setsid)
     try:
         print("Waiting for server...")
         if not wait_for_server(args.port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Server ready")
 
         bench_dir = os.path.dirname(__file__)
         eval_cmd = [
-            sys.executable, os.path.join(bench_dir, "vllm_eval_client.py"),
-            "--size", "70" if args.llama else "32",
-            "--numseqs", str(args.numseqs),
-            "--output_len", str(args.output_len),
-            "--temp", str(args.temp),
-            "--all", "--b", "1",
-            "--port", str(args.port),
+            sys.executable,
+            os.path.join(bench_dir, "vllm_eval_client.py"),
+            "--size",
+            "70" if args.llama else "32",
+            "--numseqs",
+            str(args.numseqs),
+            "--output_len",
+            str(args.output_len),
+            "--temp",
+            str(args.temp),
+            "--all",
+            "--b",
+            "1",
+            "--port",
+            str(args.port),
         ]
         if args.llama:
             eval_cmd.append("--llama")

--- a/bench/server_lifecycle.py
+++ b/bench/server_lifecycle.py
@@ -1,0 +1,14 @@
+import socket
+
+
+def is_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
+
+
+def ensure_port_available(port: int, service_name: str) -> None:
+    if is_port_in_use(port):
+        raise RuntimeError(
+            f"Port {port} is already in use. Stop the existing {service_name} server or choose a different --port before launching a new benchmark."
+        )

--- a/bench/test_server_lifecycle.py
+++ b/bench/test_server_lifecycle.py
@@ -1,0 +1,36 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bench.server_lifecycle import ensure_port_available, is_port_in_use
+
+
+class ServerLifecycleTests(unittest.TestCase):
+    @patch("bench.server_lifecycle.socket.socket")
+    def test_is_port_in_use_true_when_connect_succeeds(self, socket_cls):
+        sock = socket_cls.return_value.__enter__.return_value
+        sock.connect_ex.return_value = 0
+
+        self.assertTrue(is_port_in_use(40020))
+
+    @patch("bench.server_lifecycle.socket.socket")
+    def test_is_port_in_use_false_when_connect_fails(self, socket_cls):
+        sock = socket_cls.return_value.__enter__.return_value
+        sock.connect_ex.return_value = 111
+
+        self.assertFalse(is_port_in_use(40020))
+
+    @patch("bench.server_lifecycle.is_port_in_use", return_value=True)
+    def test_ensure_port_available_raises_for_busy_port(self, _port_check):
+        with self.assertRaises(RuntimeError) as error:
+            ensure_port_available(40020, "vLLM")
+
+        self.assertIn("Port 40020 is already in use", str(error.exception))
+        self.assertIn("different --port", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ssd/engine/model_runner.py
+++ b/ssd/engine/model_runner.py
@@ -1,4 +1,3 @@
-
 import pickle
 import time
 import torch
@@ -17,9 +16,9 @@ from ssd.layers.sampler import Sampler
 from ssd.utils.context import set_context, reset_context, get_context
 from ssd.utils.loader import load_model
 from ssd.engine.helpers.runner_helpers import (
-    prepare_decode_tensors_from_seqs, 
-    prepare_block_tables_from_seqs, 
-    prepare_prefill_tensors_from_seqs
+    prepare_decode_tensors_from_seqs,
+    prepare_block_tables_from_seqs,
+    prepare_prefill_tensors_from_seqs,
 )
 from ssd.engine.helpers.cudagraph_helpers import (
     run_verify_cudagraph,
@@ -32,31 +31,58 @@ from ssd.engine.helpers.cudagraph_helpers import (
     capture_glue_decode_cudagraph,
     get_custom_mask,
 )
-    
+
 
 class ModelRunner:
-
-    def __init__(self, config: Config, rank: int, event: Event | list[Event], is_draft: bool = False, num_tp_gpus: int = -1, init_q = None):
-        if config.verbose: print(f'ModelRunner init got args: rank={rank}, is_draft={is_draft}, num_tp_gpus={num_tp_gpus}', flush=True)
+    def __init__(
+        self,
+        config: Config,
+        rank: int,
+        event: Event | list[Event],
+        is_draft: bool = False,
+        num_tp_gpus: int = -1,
+        init_q=None,
+    ):
+        if config.verbose:
+            print(
+                f"ModelRunner init got args: rank={rank}, is_draft={is_draft}, num_tp_gpus={num_tp_gpus}",
+                flush=True,
+            )
         self.config = config
-        
-        assert is_draft in [True, False], "ERROR in ModelRunner: is_draft must be True or False"
+        self.verbose = config.verbose
+
+        assert is_draft in [True, False], (
+            "ERROR in ModelRunner: is_draft must be True or False"
+        )
         self.is_draft = is_draft
-        if self.is_draft: 
+        if self.is_draft:
             if config.draft_hf_config.torch_dtype != config.hf_config.torch_dtype:
                 if self.verbose:
-                    print(f"Warning: Draft dtype {config.draft_hf_config.torch_dtype} differs from target {config.hf_config.torch_dtype}. Casting draft to {config.hf_config.torch_dtype}.")
+                    print(
+                        f"Warning: Draft dtype {config.draft_hf_config.torch_dtype} differs from target {config.hf_config.torch_dtype}. Casting draft to {config.hf_config.torch_dtype}."
+                    )
                 config.draft_hf_config.torch_dtype = config.hf_config.torch_dtype
-            assert (config.draft_hf_config.vocab_size == config.hf_config.vocab_size) or config.use_eagle, "ERROR in ModelRunner: draft_hf_config.vocab_size != hf_config.vocab_size"
-        
+            assert (
+                config.draft_hf_config.vocab_size == config.hf_config.vocab_size
+            ) or config.use_eagle, (
+                "ERROR in ModelRunner: draft_hf_config.vocab_size != hf_config.vocab_size"
+            )
+
         self.hf_config = config.hf_config if not is_draft else config.draft_hf_config
         self.block_size = config.kvcache_block_size
         self.enforce_eager = config.enforce_eager
-        self.tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_path if config.tokenizer_path else config.model, use_fast=True)
-        self.max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            config.tokenizer_path if config.tokenizer_path else config.model,
+            use_fast=True,
+        )
+        self.max_num_blocks = (
+            config.max_model_len + self.block_size - 1
+        ) // self.block_size
 
-        assert self.hf_config is not None, "ERROR in ModelRunner: hf_config is None" # this implies boundedness to the end 
-        
+        assert self.hf_config is not None, (
+            "ERROR in ModelRunner: hf_config is None"
+        )  # this implies boundedness to the end
+
         # TODO: Get rid of this.
         if self.is_draft:
             should_use_dist = self.config.draft_async
@@ -73,113 +99,163 @@ class ModelRunner:
             if self.is_draft:
                 # [N, 3] int64, {(seq_id, len(new_suffix), rec_token): (speculated_tokens, logits_q)}
                 self.prev_fork_keys: torch.Tensor | None = None
-                self.prev_fork_block_tables: torch.Tensor | None = None  # [N, M] int32 with -1 padding
+                self.prev_fork_block_tables: torch.Tensor | None = (
+                    None  # [N, M] int32 with -1 padding
+                )
 
-        self.num_tp_gpus = num_tp_gpus # will be in [1 if no dist, num_gpus if not async, num_gpus-1 if async]
-        
-        if self.world_size == 1: # sync speculation or genuine single gpu 
-            assert (config.speculate and not config.draft_async) or self.num_tp_gpus == 1, "ERROR in ModelRunner: draft and async must be False or num_tp_gpus=1"
+        self.num_tp_gpus = num_tp_gpus  # will be in [1 if no dist, num_gpus if not async, num_gpus-1 if async]
 
-        self.verbose = config.verbose
+        if self.world_size == 1:  # sync speculation or genuine single gpu
+            assert (
+                config.speculate and not config.draft_async
+            ) or self.num_tp_gpus == 1, (
+                "ERROR in ModelRunner: draft and async must be False or num_tp_gpus=1"
+            )
+
         self.draft_async = config.draft_async
         self.event = event
-        self._exiting = False 
-        
+        self._exiting = False
+
         torch.cuda.set_device(self.rank)
-        self.device = torch.device(f'cuda:{self.rank}') 
-        
-        # cudagraph logic for FlashInfer kernels, need diff wrapper for each batch size we make a graph for 
+        self.device = torch.device(f"cuda:{self.rank}")
+
+        # cudagraph logic for FlashInfer kernels, need diff wrapper for each batch size we make a graph for
         if is_draft and config.draft_async:
             self._init_flashinfer_wrappers()
-        
-        if self.verbose: print(f'INSIDE MODEL RUNNER INIT, DRAFT={is_draft}', flush=True)
-        self.tp_pg = None 
 
-        if should_use_dist: 
-            default_port = 1223 
+        if self.verbose:
+            print(f"INSIDE MODEL RUNNER INIT, DRAFT={is_draft}", flush=True)
+        self.tp_pg = None
+
+        if should_use_dist:
+            default_port = 1223
             dist.init_process_group(
-                "nccl", f"tcp://localhost:{default_port}",
+                "nccl",
+                f"tcp://localhost:{default_port}",
                 world_size=self.world_size,
                 rank=self.rank,
                 device_id=self.device,
             )
 
-            self.tp_pg = dist.new_group(ranks=list(range(self.num_tp_gpus))) # everyone should see the new_group init even if not in group 
+            self.tp_pg = dist.new_group(
+                ranks=list(range(self.num_tp_gpus))
+            )  # everyone should see the new_group init even if not in group
 
         default_dtype = torch.get_default_dtype()
         torch.set_default_dtype(self.hf_config.torch_dtype)
         torch.set_default_device("cuda")
-        
+
         if self.is_draft:
             assert num_tp_gpus == 1, "ERROR in ModelRunner: draft should have tp_size=1"
-            self.tp_pg = None # every rank is given an object from self.tp_pg, even tho draft doesnt participate it gets GROUP_NON_MEMBER object != None back, so we can't assert None here, we 
-        
-        print(f'[model_runner] about to setup and warmup model and cudagraphs, is use_eagle={self.use_eagle}', flush=True)
-        model_type = self.setup_and_warmup_model_and_cudagraphs(config, self.hf_config, init_q, is_draft)
+            self.tp_pg = None  # every rank is given an object from self.tp_pg, even tho draft doesnt participate it gets GROUP_NON_MEMBER object != None back, so we can't assert None here, we
 
-        if self.verbose: print(f'-----CAPTURED {model_type}CUDAGRAPH----', flush=True)
+        print(
+            f"[model_runner] about to setup and warmup model and cudagraphs, is use_eagle={self.use_eagle}",
+            flush=True,
+        )
+        model_type = self.setup_and_warmup_model_and_cudagraphs(
+            config, self.hf_config, init_q, is_draft
+        )
+
+        if self.verbose:
+            print(f"-----CAPTURED {model_type}CUDAGRAPH----", flush=True)
         torch.set_default_device("cpu")
         torch.set_default_dtype(default_dtype)
 
         if self.config.draft_async:
             if self.config.fan_out_list is None:
-                self.config.fan_out_list = [
-                    self.config.async_fan_out] * (self.config.speculate_k + 1)
+                self.config.fan_out_list = [self.config.async_fan_out] * (
+                    self.config.speculate_k + 1
+                )
 
-            self.config.fan_out_t = torch.tensor(self.config.fan_out_list, device=self.device)
-            self.config.fan_out_t_miss = torch.tensor(self.config.fan_out_list_miss, device=self.device)
-            assert len(self.config.fan_out_list) == self.config.speculate_k + \
-                1, "ERROR in Config: fan_out_list must be length speculate_k + 1"
-            assert any(f > 0 for f in self.config.fan_out_list), "ERROR in Config: fan_out_list must be > 0"
+            self.config.fan_out_t = torch.tensor(
+                self.config.fan_out_list, device=self.device
+            )
+            self.config.fan_out_t_miss = torch.tensor(
+                self.config.fan_out_list_miss, device=self.device
+            )
+            assert len(self.config.fan_out_list) == self.config.speculate_k + 1, (
+                "ERROR in Config: fan_out_list must be length speculate_k + 1"
+            )
+            assert any(f > 0 for f in self.config.fan_out_list), (
+                "ERROR in Config: fan_out_list must be > 0"
+            )
             self.config.MQ_LEN = sum(self.config.fan_out_list)
-            print(f'F={self.config.async_fan_out}, fan_out_list={self.config.fan_out_list}, fan_out_list_miss={self.config.fan_out_list_miss}, MQ_LEN={self.config.MQ_LEN}', flush=True)
+            print(
+                f"F={self.config.async_fan_out}, fan_out_list={self.config.fan_out_list}, fan_out_list_miss={self.config.fan_out_list_miss}, MQ_LEN={self.config.MQ_LEN}",
+                flush=True,
+            )
 
-        if should_use_dist: # (draft model when async=False or just single gpu logic) doesn't even enter this loop 
-            if self.is_draft and self.draft_async: 
-                pass # handled on draft runner after this init, includes doing draft_loop
-            elif self.rank == 0: # target in a distributed setup 
+        if should_use_dist:  # (draft model when async=False or just single gpu logic) doesn't even enter this loop
+            if self.is_draft and self.draft_async:
+                pass  # handled on draft runner after this init, includes doing draft_loop
+            elif self.rank == 0:  # target in a distributed setup
                 # Try to clean up any existing shared memory first
                 try:
                     existing_shm = SharedMemory(name="ssd")
-                    existing_shm.close() # here we bind it 
+                    existing_shm.close()  # here we bind it
                     existing_shm.unlink()
                 except FileNotFoundError:
-                    # can proceed, nothing to clean up 
+                    # can proceed, nothing to clean up
                     pass
-                
+
                 self.shm = SharedMemory(name="ssd", create=True, size=2**28)
-                dist.barrier(group=self.tp_pg, device_ids=[self.rank]) # leader on tp_group 
-            else: 
-                dist.barrier(group=self.tp_pg, device_ids=[self.rank]) # follower on tp_group, don't want them hooking onto shm before its been created 
+                dist.barrier(
+                    group=self.tp_pg, device_ids=[self.rank]
+                )  # leader on tp_group
+            else:
+                dist.barrier(
+                    group=self.tp_pg, device_ids=[self.rank]
+                )  # follower on tp_group, don't want them hooking onto shm before its been created
                 self.shm = SharedMemory(name="ssd")
                 self.loop()
-                
-        if self.verbose: print(f'-----{model_type}MODEL RUNNER INITIALIZED----', flush=True)
+
+        if self.verbose:
+            print(f"-----{model_type}MODEL RUNNER INITIALIZED----", flush=True)
 
     def _init_flashinfer_wrappers(self):
         """Initialize FlashInfer wrappers for draft async mode."""
         self.workspace_buffer = torch.zeros(
-            512 * 1024 * 1024, dtype=torch.uint8, device=f"cuda:{self.rank}") 
-        
-        if self.config.enforce_eager: 
-            self.only_prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(self.workspace_buffer, "NHD")
-        else: 
+            512 * 1024 * 1024, dtype=torch.uint8, device=f"cuda:{self.rank}"
+        )
+
+        if self.config.enforce_eager:
+            self.only_prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                self.workspace_buffer, "NHD"
+            )
+        else:
             max_bs = min(self.config.max_num_seqs, 512)
-            max_num_blocks = (self.config.max_model_len + self.block_size - 1) // self.block_size
-            
+            max_num_blocks = (
+                self.config.max_model_len + self.block_size - 1
+            ) // self.block_size
+
             # FlashInfer kernel tensors
             # pages_for_max_len = (self.config.max_model_len + self.block_size - 1) // self.block_size
             last_page_len_max_len = self.config.max_model_len % self.block_size
-            last_page_len_max_len = self.block_size if last_page_len_max_len == 0 else last_page_len_max_len
+            last_page_len_max_len = (
+                self.block_size if last_page_len_max_len == 0 else last_page_len_max_len
+            )
             MQ_LEN = self.config.async_fan_out * (self.config.speculate_k + 1)
-            
-            cu_seqlens_q = torch.empty(max_bs + 1, dtype=torch.int32, device=self.device)
+
+            cu_seqlens_q = torch.empty(
+                max_bs + 1, dtype=torch.int32, device=self.device
+            )
             kv_indptr = torch.empty(max_bs + 1, dtype=torch.int32, device=self.device)
-            kv_indices = torch.empty(max_bs * max_num_blocks, dtype=torch.int32, device=self.device)
-            kv_last_page_len = torch.empty(max_bs, dtype=torch.int32, device=self.device)
-            custom_mask_buf = torch.empty(max_bs * MQ_LEN * self.config.max_model_len, dtype=torch.uint8, device=self.device)
-            mask_indptr_buf = torch.empty(max_bs + 1, dtype=torch.int32, device=self.device)
-            
+            kv_indices = torch.empty(
+                max_bs * max_num_blocks, dtype=torch.int32, device=self.device
+            )
+            kv_last_page_len = torch.empty(
+                max_bs, dtype=torch.int32, device=self.device
+            )
+            custom_mask_buf = torch.empty(
+                max_bs * MQ_LEN * self.config.max_model_len,
+                dtype=torch.uint8,
+                device=self.device,
+            )
+            mask_indptr_buf = torch.empty(
+                max_bs + 1, dtype=torch.int32, device=self.device
+            )
+
             # Create graph_bs_list to match what will be used in cudagraph_helpers.py
             graph_bs_list = [1]
             for bs in [2, 4, 8] + list(range(16, max_bs + 1, 16)):
@@ -188,38 +264,51 @@ class ModelRunner:
             if max_bs not in graph_bs_list:
                 graph_bs_list.append(max_bs)
             graph_bs_list.sort()
-            
+
             # Create a dict of wrappers, one for each bs we will touch in cudagraph_helpers.py
             self.prefill_wrappers = {}
-            print(f'[model_runner about to wrapper.init()] graph_bs_list={graph_bs_list}', flush=True)
+            print(
+                f"[model_runner about to wrapper.init()] graph_bs_list={graph_bs_list}",
+                flush=True,
+            )
             for bs in graph_bs_list:
-                self.prefill_wrappers[bs] = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-                    self.workspace_buffer, "NHD", 
-                    use_cuda_graph=True, 
-                    qo_indptr_buf=cu_seqlens_q[:bs + 1],
-                    paged_kv_indptr_buf=kv_indptr[:bs + 1],
-                    paged_kv_indices_buf=kv_indices[:bs * max_num_blocks],
-                    paged_kv_last_page_len_buf=kv_last_page_len[:bs],
-                    custom_mask_buf=custom_mask_buf[:bs * MQ_LEN * self.config.max_model_len],
-                    mask_indptr_buf=mask_indptr_buf[:bs + 1],
+                self.prefill_wrappers[bs] = (
+                    flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                        self.workspace_buffer,
+                        "NHD",
+                        use_cuda_graph=True,
+                        qo_indptr_buf=cu_seqlens_q[: bs + 1],
+                        paged_kv_indptr_buf=kv_indptr[: bs + 1],
+                        paged_kv_indices_buf=kv_indices[: bs * max_num_blocks],
+                        paged_kv_last_page_len_buf=kv_last_page_len[:bs],
+                        custom_mask_buf=custom_mask_buf[
+                            : bs * MQ_LEN * self.config.max_model_len
+                        ],
+                        mask_indptr_buf=mask_indptr_buf[: bs + 1],
+                    )
                 )
-            print(f'wrapper backend is {self.prefill_wrappers[bs]._backend}', flush=True)
+            print(
+                f"wrapper backend is {self.prefill_wrappers[bs]._backend}", flush=True
+            )
 
-
-    def setup_and_warmup_model_and_cudagraphs(self, config: Config, hf_config: AutoConfig, init_q=None, is_draft=False):
-        # cudagraphs 
+    def setup_and_warmup_model_and_cudagraphs(
+        self, config: Config, hf_config: AutoConfig, init_q=None, is_draft=False
+    ):
+        # cudagraphs
         self.graph_vars = {}
         self.graph_pools = {}
         self.graphs = {}
         self.graph_bs_list = {}
 
-        assert hasattr(hf_config, 'model_type'), "ERROR in ModelRunner: hf_config.model_type is not set"
+        assert hasattr(hf_config, "model_type"), (
+            "ERROR in ModelRunner: hf_config.model_type is not set"
+        )
         if config.use_eagle and is_draft:
-            print(f'[EAGLE3] Loading Eagle3DraftForCausalLM as model_class', flush=True)
+            print(f"[EAGLE3] Loading Eagle3DraftForCausalLM as model_class", flush=True)
             model_class = Eagle3DraftForCausalLM
-        elif hf_config.model_type == 'llama':
+        elif hf_config.model_type == "llama":
             model_class = LlamaForCausalLM
-        elif hf_config.model_type == 'qwen3':
+        elif hf_config.model_type == "qwen3":
             model_class = Qwen3ForCausalLM
         else:
             raise ValueError(f"Unsupported model type: {hf_config.model_type}")
@@ -235,40 +324,55 @@ class ModelRunner:
             tp_group=self.tp_pg,
             tp_size=self.num_tp_gpus,
         )
-        
+
         if config.use_eagle:
-            kwargs['use_eagle'] = True
-            kwargs['eagle_layers'] = self.config.eagle_layers
-            
+            kwargs["use_eagle"] = True
+            kwargs["eagle_layers"] = self.config.eagle_layers
+
         if model_class == Eagle3DraftForCausalLM:
-            kwargs['d_model_target'] = config.d_model_target
-            kwargs['debug_mode'] = config.debug_mode
-            
+            kwargs["d_model_target"] = config.d_model_target
+            kwargs["debug_mode"] = config.debug_mode
+
         self.model = model_class(**kwargs)
 
         model_type = "DRAFT " if self.is_draft else "TARGET "
         if self.verbose:
-            print(f'-----LOADING {model_type}MODEL----', flush=True)
-        
+            print(f"-----LOADING {model_type}MODEL----", flush=True)
+
         # Pass tokenizer_path as target_path if it's available (mostly for Eagle draft)
-        target_path = getattr(config, 'tokenizer_path', None)
-        target_hidden_size = getattr(config, 'd_model_target', None)
-        load_model(self.model, config.model, target_path=target_path, target_hidden_size=target_hidden_size)
-        
+        target_path = getattr(config, "tokenizer_path", None)
+        target_hidden_size = getattr(config, "d_model_target", None)
+        load_model(
+            self.model,
+            config.model,
+            target_path=target_path,
+            target_hidden_size=target_hidden_size,
+        )
+
         if config.draft_async:  # move this here so we don't get a timeout waiting for draft rank while load_model happens?
             self.async_pg = dist.new_group(ranks=[0, self.draft_rank])
         if self.verbose:
-            print(f'-----{model_type}MODEL LOADED----', flush=True)
+            print(f"-----{model_type}MODEL LOADED----", flush=True)
         if config.sampler_x is not None:
-            assert config.draft_async, "ERROR in ModelRunner: sampler_x requires draft_async"
-            assert sum(config.fan_out_list) == sum(config.fan_out_list_miss) == config.async_fan_out * (config.speculate_k + 1), "ERROR in ModelRunner: fancy sampling only supported for constant fan out for now."
+            assert config.draft_async, (
+                "ERROR in ModelRunner: sampler_x requires draft_async"
+            )
+            assert (
+                sum(config.fan_out_list)
+                == sum(config.fan_out_list_miss)
+                == config.async_fan_out * (config.speculate_k + 1)
+            ), (
+                "ERROR in ModelRunner: fancy sampling only supported for constant fan out for now."
+            )
 
-        self.sampler = Sampler(sampler_x=config.sampler_x, async_fan_out=config.async_fan_out)
+        self.sampler = Sampler(
+            sampler_x=config.sampler_x, async_fan_out=config.async_fan_out
+        )
         if self.verbose:
-            print(f'-----WARMING UP {model_type}MODEL----', flush=True)
+            print(f"-----WARMING UP {model_type}MODEL----", flush=True)
         self.warmup_model()
         if self.verbose:
-            print(f'-----ALLOCATING {model_type}KV CACHE----', flush=True)
+            print(f"-----ALLOCATING {model_type}KV CACHE----", flush=True)
         self.allocate_kv_cache()
         if init_q is not None:
             # super().__init__() runs warmup and calculates num_kvcache_blocks, pass that up
@@ -276,26 +380,54 @@ class ModelRunner:
             init_q.close()
 
         if not self.enforce_eager:
-            # if not self.is_draft or (self.is_draft and self.config.draft_async and self.config.speculate): 
-            decode_graph_vars, decode_graph_pool, decode_graphs, decode_graph_bs_list = capture_cudagraph(self)  # decode cudagraph, draft needs in spec and target in normal
+            # if not self.is_draft or (self.is_draft and self.config.draft_async and self.config.speculate):
+            (
+                decode_graph_vars,
+                decode_graph_pool,
+                decode_graphs,
+                decode_graph_bs_list,
+            ) = capture_cudagraph(
+                self
+            )  # decode cudagraph, draft needs in spec and target in normal
             self.graph_vars["decode"] = decode_graph_vars
             self.graph_pools["decode"] = decode_graph_pool
             self.graphs["decode"] = decode_graphs
             self.graph_bs_list["decode"] = decode_graph_bs_list
-            if self.config.speculate and not (self.is_draft and self.config.use_eagle):  # verify CG: target always, non-EAGLE draft for fan-out; EAGLE draft uses glue_decode CG instead
-                verify_graph_vars, verify_graph_pool, verify_graphs, verify_graph_bs_list = capture_verify_cudagraph(self)
+            if (
+                self.config.speculate and not (self.is_draft and self.config.use_eagle)
+            ):  # verify CG: target always, non-EAGLE draft for fan-out; EAGLE draft uses glue_decode CG instead
+                (
+                    verify_graph_vars,
+                    verify_graph_pool,
+                    verify_graphs,
+                    verify_graph_bs_list,
+                ) = capture_verify_cudagraph(self)
                 self.graph_vars["verify"] = verify_graph_vars
                 self.graph_pools["verify"] = verify_graph_pool
                 self.graphs["verify"] = verify_graphs
                 self.graph_bs_list["verify"] = verify_graph_bs_list
             if self.config.speculate and self.is_draft and self.config.draft_async:
-                fi_tree_decode_graph_vars, fi_tree_decode_graph_pool, fi_tree_decode_graphs, fi_tree_decode_graph_bs_list = capture_fi_tree_decode_cudagraph(self)  # fi tree decode cudagraph, draft only
+                (
+                    fi_tree_decode_graph_vars,
+                    fi_tree_decode_graph_pool,
+                    fi_tree_decode_graphs,
+                    fi_tree_decode_graph_bs_list,
+                ) = capture_fi_tree_decode_cudagraph(
+                    self
+                )  # fi tree decode cudagraph, draft only
                 self.graph_vars["fi_tree_decode"] = fi_tree_decode_graph_vars
                 self.graph_pools["fi_tree_decode"] = fi_tree_decode_graph_pool
                 self.graphs["fi_tree_decode"] = fi_tree_decode_graphs
                 self.graph_bs_list["fi_tree_decode"] = fi_tree_decode_graph_bs_list
-            if self.config.speculate and self.is_draft and self.config.draft_async and self.config.use_eagle:
-                glue_gv, glue_pool, glue_graphs, glue_bs_list = capture_glue_decode_cudagraph(self)
+            if (
+                self.config.speculate
+                and self.is_draft
+                and self.config.draft_async
+                and self.config.use_eagle
+            ):
+                glue_gv, glue_pool, glue_graphs, glue_bs_list = (
+                    capture_glue_decode_cudagraph(self)
+                )
                 self.graph_vars["glue_decode"] = glue_gv
                 self.graph_pools["glue_decode"] = glue_pool
                 self.graphs["glue_decode"] = glue_graphs
@@ -309,7 +441,10 @@ class ModelRunner:
             return
         self._exiting = True
         if self.verbose:
-            print(f"[ModelRunner] Exit start (rank={self.rank}, draft={self.is_draft}, hard={hard})", flush=True)
+            print(
+                f"[ModelRunner] Exit start (rank={self.rank}, draft={self.is_draft}, hard={hard})",
+                flush=True,
+            )
         # 1) Notify draft first (target rank 0 only)
         try:
             self.send_draft_exit_signal()
@@ -350,7 +485,11 @@ class ModelRunner:
             except Exception:
                 pass
             try:
-                if self.world_size > 1 and hasattr(self, "tp_pg") and self.tp_pg is not None:
+                if (
+                    self.world_size > 1
+                    and hasattr(self, "tp_pg")
+                    and self.tp_pg is not None
+                ):
                     dist.destroy_process_group(self.tp_pg)
             except Exception:
                 pass
@@ -388,7 +527,7 @@ class ModelRunner:
         t = torch.empty(shape, dtype=dtype, device=self.device)
         dist.recv(t, src=0, group=self.async_pg)
         return t
-    
+
     def send_draft_exit_signal(self):
         """
         Best-effort: send cmd=2 to draft (async_pg) from TARGET rank 0.
@@ -401,11 +540,12 @@ class ModelRunner:
             dist.send(cmd, dst=self.draft_rank, group=self.async_pg)
         except Exception:
             pass
+
     def read_shm(self):
         assert self.world_size > 1 and self.rank
         self.event.wait()
         n = int.from_bytes(self.shm.buf[0:4], "little")
-        method_name, *args = pickle.loads(self.shm.buf[4:n+4])
+        method_name, *args = pickle.loads(self.shm.buf[4 : n + 4])
         self.event.clear()
         return method_name, args
 
@@ -413,9 +553,11 @@ class ModelRunner:
         assert self.world_size > 1 and not self.rank
         data = pickle.dumps([method_name, *args])
         n = len(data)
-        assert n + 4 <= self.shm.size, f"SHM overflow: {n+4} > {self.shm.size}. Increase SHM buffer size."
+        assert n + 4 <= self.shm.size, (
+            f"SHM overflow: {n + 4} > {self.shm.size}. Increase SHM buffer size."
+        )
         self.shm.buf[0:4] = n.to_bytes(4, "little")
-        self.shm.buf[4:n+4] = data
+        self.shm.buf[4 : n + 4] = data
         for event in self.event:
             event.set()
 
@@ -430,24 +572,34 @@ class ModelRunner:
     def warmup_model(self):
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
-        max_num_batched_tokens, max_model_len = self.config.max_num_batched_tokens, self.config.max_model_len
-        num_seqs = min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs)
+        max_num_batched_tokens, max_model_len = (
+            self.config.max_num_batched_tokens,
+            self.config.max_model_len,
+        )
+        num_seqs = min(
+            max_num_batched_tokens // max_model_len, self.config.max_num_seqs
+        )
         seqs = [Sequence([0] * max_model_len) for _ in range(num_seqs)]
-        
+
         hidden_states = None
         if self.config.use_eagle and self.is_draft:
             num_tokens = num_seqs * max_model_len
             d_model_target = self.config.d_model_target or 4096
-            hidden_states = torch.zeros(num_tokens, 3 * d_model_target, dtype=self.hf_config.torch_dtype, device=self.device)
-        
+            hidden_states = torch.zeros(
+                num_tokens,
+                3 * d_model_target,
+                dtype=self.hf_config.torch_dtype,
+                device=self.device,
+            )
+
         self.run(seqs, True, hidden_states=hidden_states)
         torch.cuda.empty_cache()
 
     def allocate_kv_cache(self):
-        print(f'inside allocate_kv_cache -- ', flush=True)
+        print(f"inside allocate_kv_cache -- ", flush=True)
         config = self.config
         hf_config = self.hf_config
-        
+
         # Simplify: just look at free memory on the GPU, and allocate up to gpu_memory_utilization * free.
         free, _ = torch.cuda.mem_get_info()
         num_kv_heads = hf_config.num_key_value_heads // self.num_tp_gpus
@@ -462,35 +614,48 @@ class ModelRunner:
         usable_bytes = free * config.gpu_memory_utilization
 
         if self.is_draft and self.draft_async:
-            B = config.max_num_seqs          # max concurrent sequences
-            K = config.speculate_k           # speculative steps
-            F = config.async_fan_out         # branches per step
+            B = config.max_num_seqs  # max concurrent sequences
+            K = config.speculate_k  # speculative steps
+            F = config.async_fan_out  # branches per step
             V = hf_config.vocab_size
             dtype_size = hf_config.torch_dtype.itemsize
             # Total forks = B * (K+1) * F, each fork stores (K+1)*V logits of size dtype_size
             reserved_bytes = B * (K + 1) * F * (K + 1) * V * dtype_size
             usable_bytes = max(usable_bytes - reserved_bytes, 0)
-            assert usable_bytes > 0, "ERROR: Not enough memory for draft KV cache after accounting for tree_cache for logits storage"
+            assert usable_bytes > 0, (
+                "ERROR: Not enough memory for draft KV cache after accounting for tree_cache for logits storage"
+            )
 
         config.num_kvcache_blocks = int(usable_bytes) // block_bytes
         if self.verbose:
-            print(f'KV CACHE ALLOCATION for {"TARGET" if not self.is_draft else "DRAFT"} model', flush=True)
-            print(f' free={free/1e9:.2f}GB, util={config.gpu_memory_utilization:.2f}', flush=True)
-            print(f' block_bytes={block_bytes/1e9:.2f}GB,'
-            + f' num_kvcache_blocks={config.num_kvcache_blocks}', flush=True)   
-        
+            print(
+                f"KV CACHE ALLOCATION for {'TARGET' if not self.is_draft else 'DRAFT'} model",
+                flush=True,
+            )
+            print(
+                f" free={free / 1e9:.2f}GB, util={config.gpu_memory_utilization:.2f}",
+                flush=True,
+            )
+            print(
+                f" block_bytes={block_bytes / 1e9:.2f}GB,"
+                + f" num_kvcache_blocks={config.num_kvcache_blocks}",
+                flush=True,
+            )
+
         assert config.num_kvcache_blocks > 0, "KV cache too big for free memory!"
 
-        self.kv_cache = torch.zeros( 
+        self.kv_cache = torch.zeros(
             2,
             hf_config.num_hidden_layers,
             config.num_kvcache_blocks,
             self.block_size,
             num_kv_heads,
-            hf_config.head_dim, 
+            hf_config.head_dim,
         )
-        
-        print(f"allocate_kv_cache(): kv_cache shape = {self.kv_cache.shape}", flush=True)
+
+        print(
+            f"allocate_kv_cache(): kv_cache shape = {self.kv_cache.shape}", flush=True
+        )
         layer_id = 0
         for module in self.model.modules():
             if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
@@ -499,44 +664,89 @@ class ModelRunner:
                 if self.is_draft and self.draft_async and not self.enforce_eager:
                     module.prefill_wrappers = self.prefill_wrappers
                 elif self.is_draft and self.draft_async and self.enforce_eager:
-                    module.only_prefill_wrapper = self.only_prefill_wrapper # this will make it not None so it can be used on fwd
+                    module.only_prefill_wrapper = (
+                        self.only_prefill_wrapper
+                    )  # this will make it not None so it can be used on fwd
                 layer_id += 1
 
-    
     def prepare_prefill(self, seqs: list[Sequence]):
-        input_ids, positions, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping = \
-            prepare_prefill_tensors_from_seqs(seqs, self.block_size, self.is_draft) # if one big input ids, how is attn mask handled? via cu_seqlens_q/k? 
+        (
+            input_ids,
+            positions,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            slot_mapping,
+        ) = prepare_prefill_tensors_from_seqs(
+            seqs, self.block_size, self.is_draft
+        )  # if one big input ids, how is attn mask handled? via cu_seqlens_q/k?
 
         block_tables = None
-        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
-            block_tables = prepare_block_tables_from_seqs(
-                seqs, self.is_draft)
-        
-        set_context(is_prefill=True, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k, max_seqlen_q=max_seqlen_q,
-                    max_seqlen_k=max_seqlen_k, slot_mapping=slot_mapping, context_lens=None, block_tables=block_tables)
+        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:  # prefix cache
+            block_tables = prepare_block_tables_from_seqs(seqs, self.is_draft)
+
+        set_context(
+            is_prefill=True,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            slot_mapping=slot_mapping,
+            context_lens=None,
+            block_tables=block_tables,
+        )
         return input_ids, positions
-    
-    def prepare_decode(self, seqs: list[Sequence], verify: bool = False): 
-        input_ids, positions, slot_mapping, context_lens = \
-            prepare_decode_tensors_from_seqs(seqs, self.block_size, self.is_draft, verify, self.config.speculate_k if verify else -1)
 
-        
-        block_tables = prepare_block_tables_from_seqs(seqs, self.is_draft) # if verify, set cu_seqlens_q as well
+    def prepare_decode(self, seqs: list[Sequence], verify: bool = False):
+        input_ids, positions, slot_mapping, context_lens = (
+            prepare_decode_tensors_from_seqs(
+                seqs,
+                self.block_size,
+                self.is_draft,
+                verify,
+                self.config.speculate_k if verify else -1,
+            )
+        )
 
-        if verify: ### what path does glue decode take? trace it. 
+        block_tables = prepare_block_tables_from_seqs(
+            seqs, self.is_draft
+        )  # if verify, set cu_seqlens_q as well
+
+        if verify:  ### what path does glue decode take? trace it.
             # this had [not draft and draft_async] condn before
-            cu_seqlens_q = torch.zeros(len(seqs) + 1, dtype=torch.int32, device=self.device)
-            seqlen_q = torch.full((len(seqs),), self.config.speculate_k + 1, dtype=torch.int32, device=self.device)
+            cu_seqlens_q = torch.zeros(
+                len(seqs) + 1, dtype=torch.int32, device=self.device
+            )
+            seqlen_q = torch.full(
+                (len(seqs),),
+                self.config.speculate_k + 1,
+                dtype=torch.int32,
+                device=self.device,
+            )
             cu_seqlens_q[1:] = torch.cumsum(seqlen_q, dim=0)
-            set_context(is_prefill=False, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None, 
-                       max_seqlen_q=self.config.speculate_k + 1, max_seqlen_k=0,
-                       slot_mapping=slot_mapping, context_lens=context_lens, 
-                       block_tables=block_tables) 
-        else: # sq_decode path, draft (sync spec) or target (normal)
-            set_context(is_prefill=False, cu_seqlens_q=None, cu_seqlens_k=None, 
-                       max_seqlen_q=0, max_seqlen_k=0, slot_mapping=slot_mapping, 
-                       context_lens=context_lens, block_tables=block_tables)
-        
+            set_context(
+                is_prefill=False,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=None,
+                max_seqlen_q=self.config.speculate_k + 1,
+                max_seqlen_k=0,
+                slot_mapping=slot_mapping,
+                context_lens=context_lens,
+                block_tables=block_tables,
+            )
+        else:  # sq_decode path, draft (sync spec) or target (normal)
+            set_context(
+                is_prefill=False,
+                cu_seqlens_q=None,
+                cu_seqlens_k=None,
+                max_seqlen_q=0,
+                max_seqlen_k=0,
+                slot_mapping=slot_mapping,
+                context_lens=context_lens,
+                block_tables=block_tables,
+            )
+
         return input_ids, positions
 
     def prepare_sample(self, seqs: list[Sequence]):
@@ -546,37 +756,56 @@ class ModelRunner:
                 temperatures.append(seq.draft_temperature)
             else:
                 temperatures.append(seq.temperature)
-        temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
+        temperatures = torch.tensor(
+            temperatures, dtype=torch.float32, pin_memory=True
+        ).cuda(non_blocking=True)
         return temperatures
 
     def eager_tree_decode_plan(self, input_ids, positions, step, cache_hits):
         """Plan FlashInfer for tree decode in eager mode"""
-        assert self.is_draft and self.config.draft_async, "ERROR in eager_tree_decode_plan: not a draft async model"
+        assert self.is_draft and self.config.draft_async, (
+            "ERROR in eager_tree_decode_plan: not a draft async model"
+        )
         context = get_context()
-        
+
         K, F = self.config.speculate_k, self.config.async_fan_out
         # MQ_LEN = F * (K+1)
         MQ_LEN = self.config.MQ_LEN
-        flat_batch_size = input_ids.size(0) 
-        B = flat_batch_size // MQ_LEN # [N] tokens = B * sum(fan_out_list)
-        
+        flat_batch_size = input_ids.size(0)
+        B = flat_batch_size // MQ_LEN  # [N] tokens = B * sum(fan_out_list)
+
         # Convert block_tables to FlashInfer format
-        block_tables = context.block_tables # [B, M]
-        context_lens = context.context_lens # [B]
-        
-        counts = (context_lens + self.block_size - 1) // self.block_size # [B]
-        kv_indptr = torch.cat([torch.tensor([0], device=block_tables.device),
-                               counts.cumsum(dim=0)]).to(torch.int32)  
-        mask = torch.arange(block_tables.size(1), device=block_tables.device)[None, :] < counts[:, None]
-        kv_indices = block_tables[mask]                    # flattened page ids
-        
+        block_tables = context.block_tables  # [B, M]
+        context_lens = context.context_lens  # [B]
+
+        counts = (context_lens + self.block_size - 1) // self.block_size  # [B]
+        kv_indptr = torch.cat(
+            [torch.tensor([0], device=block_tables.device), counts.cumsum(dim=0)]
+        ).to(torch.int32)
+        mask = (
+            torch.arange(block_tables.size(1), device=block_tables.device)[None, :]
+            < counts[:, None]
+        )
+        kv_indices = block_tables[mask]  # flattened page ids
+
         # Last-page actual token count per request
-        kv_last_page_len = (context_lens % self.block_size)
+        kv_last_page_len = context_lens % self.block_size
         kv_last_page_len[kv_last_page_len == 0] = self.block_size
         kv_last_page_len = kv_last_page_len.to(torch.int32)
-        cu_seqlens_q = torch.arange(B + 1, device=self.device, dtype=torch.int32) * MQ_LEN # assumes same MQ_LEN across batch dimension 
-        custom_mask = get_custom_mask(self.config, context_lens, step, K, F, B, device=self.device, cache_hits=cache_hits)
-        
+        cu_seqlens_q = (
+            torch.arange(B + 1, device=self.device, dtype=torch.int32) * MQ_LEN
+        )  # assumes same MQ_LEN across batch dimension
+        custom_mask = get_custom_mask(
+            self.config,
+            context_lens,
+            step,
+            K,
+            F,
+            B,
+            device=self.device,
+            cache_hits=cache_hits,
+        )
+
         self.only_prefill_wrapper.plan(
             cu_seqlens_q,
             kv_indptr,
@@ -592,43 +821,96 @@ class ModelRunner:
         )
 
     @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool, last_only: bool = True, tree_decode_step: int = -1, cache_hits: torch.Tensor | None = None, hidden_states: torch.Tensor | None = None):
-        is_tree_decode = self.is_draft and self.config.draft_async and tree_decode_step >= 0
+    def run_model(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        is_prefill: bool,
+        last_only: bool = True,
+        tree_decode_step: int = -1,
+        cache_hits: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+    ):
+        is_tree_decode = (
+            self.is_draft and self.config.draft_async and tree_decode_step >= 0
+        )
         is_mq_kp1 = self.config.speculate and not last_only
         spec_and_dec = not is_prefill and self.config.speculate
 
-        assert not (is_prefill and not last_only), "ERROR in run_model: is_prefill and not last_only"
-        
+        assert not (is_prefill and not last_only), (
+            "ERROR in run_model: is_prefill and not last_only"
+        )
+
         if is_prefill or self.enforce_eager:
             if is_tree_decode:
-                self.eager_tree_decode_plan(input_ids, positions, tree_decode_step, cache_hits)
-            
-            if self.config.use_eagle: 
+                self.eager_tree_decode_plan(
+                    input_ids, positions, tree_decode_step, cache_hits
+                )
+
+            if self.config.use_eagle:
                 if self.is_draft:
-                    assert hidden_states is not None, "hidden_states required for EAGLE draft"
+                    assert hidden_states is not None, (
+                        "hidden_states required for EAGLE draft"
+                    )
                     assert isinstance(self.model, Eagle3DraftForCausalLM)
                     prenorm = self.model(input_ids, positions, hidden_states)
                     logits = self.model.compute_logits(prenorm, last_only)
-                    return logits, prenorm  # return prenorm as conditioning vector for next iteration
-                else: # target gets outputs and hidden states
-                    outputs, eagle_acts = self.model(input_ids, positions) # target fwd when eagle enabled hooks into activations for eagle conditioning
+                    return (
+                        logits,
+                        prenorm,
+                    )  # return prenorm as conditioning vector for next iteration
+                else:  # target gets outputs and hidden states
+                    outputs, eagle_acts = self.model(
+                        input_ids, positions
+                    )  # target fwd when eagle enabled hooks into activations for eagle conditioning
                     logits = self.model.compute_logits(outputs, last_only)
-                    return logits, eagle_acts  # return eagle_acts as conditioning vector for draft
-            else: 
+                    return (
+                        logits,
+                        eagle_acts,
+                    )  # return eagle_acts as conditioning vector for draft
+            else:
                 outputs = self.model(input_ids, positions)
                 logits = self.model.compute_logits(outputs, last_only)
-                return logits 
+                return logits
 
         elif is_tree_decode:
-            return run_fi_tree_decode_cudagraph(self, input_ids, positions, last_only, self.graph_vars["fi_tree_decode"], tree_decode_step, cache_hits, hidden_states=hidden_states)
-        elif is_mq_kp1 and hidden_states is not None and "glue_decode" in self.graph_vars:
+            return run_fi_tree_decode_cudagraph(
+                self,
+                input_ids,
+                positions,
+                last_only,
+                self.graph_vars["fi_tree_decode"],
+                tree_decode_step,
+                cache_hits,
+                hidden_states=hidden_states,
+            )
+        elif (
+            is_mq_kp1 and hidden_states is not None and "glue_decode" in self.graph_vars
+        ):
             # EAGLE draft glue decode with 2K+1 per seq
-            return run_glue_decode_cudagraph(self, input_ids, positions, last_only, self.graph_vars["glue_decode"], hidden_states)
-        elif is_mq_kp1: # verify or non-EAGLE glue decode, "verify" ~ mq decode of len K+1
-            return run_verify_cudagraph(self, input_ids, positions, last_only, self.graph_vars["verify"])
-        else: # draft decoding in sync spec or JIT single-token decode
-            return run_decode_cudagraph(self, input_ids, positions, last_only, self.graph_vars["decode"], hidden_states=hidden_states)
-
+            return run_glue_decode_cudagraph(
+                self,
+                input_ids,
+                positions,
+                last_only,
+                self.graph_vars["glue_decode"],
+                hidden_states,
+            )
+        elif (
+            is_mq_kp1
+        ):  # verify or non-EAGLE glue decode, "verify" ~ mq decode of len K+1
+            return run_verify_cudagraph(
+                self, input_ids, positions, last_only, self.graph_vars["verify"]
+            )
+        else:  # draft decoding in sync spec or JIT single-token decode
+            return run_decode_cudagraph(
+                self,
+                input_ids,
+                positions,
+                last_only,
+                self.graph_vars["decode"],
+                hidden_states=hidden_states,
+            )
 
     # should add spec_k that just loops this k times
     def run(
@@ -637,9 +919,13 @@ class ModelRunner:
         is_prefill: bool,
         last_only: bool = True,
         draft_return_logits: bool = False,
-        hidden_states: torch.Tensor | None = None
+        hidden_states: torch.Tensor | None = None,
     ) -> list[int] | tuple[list[int], torch.Tensor]:
-        _pt = os.environ.get("SSD_PROFILE_TARGET", "0") == "1" and not is_prefill and not last_only
+        _pt = (
+            os.environ.get("SSD_PROFILE_TARGET", "0") == "1"
+            and not is_prefill
+            and not last_only
+        )
         if _pt:
             torch.cuda.synchronize()
             _r0 = time.perf_counter()
@@ -658,17 +944,25 @@ class ModelRunner:
         conditioning = None
         if self.config.use_eagle:
             logits, conditioning = self.run_model(
-                input_ids, positions, is_prefill, last_only, hidden_states=hidden_states)
+                input_ids, positions, is_prefill, last_only, hidden_states=hidden_states
+            )
         else:
-            logits = self.run_model(input_ids, positions, is_prefill, last_only, hidden_states=hidden_states)
+            logits = self.run_model(
+                input_ids, positions, is_prefill, last_only, hidden_states=hidden_states
+            )
 
         if _pt:
             torch.cuda.synchronize()
             _r2 = time.perf_counter()
-            print(f"[PROFILE target_run] prepare_decode={(_r1-_r0)*1000:.2f}ms run_model={(_r2-_r1)*1000:.2f}ms eagle={self.config.use_eagle} n_ids={input_ids.shape[0]}", flush=True)
+            print(
+                f"[PROFILE target_run] prepare_decode={(_r1 - _r0) * 1000:.2f}ms run_model={(_r2 - _r1) * 1000:.2f}ms eagle={self.config.use_eagle} n_ids={input_ids.shape[0]}",
+                flush=True,
+            )
 
         if last_only:
-            token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+            token_ids = (
+                self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+            )
             reset_context()
             if conditioning is not None:
                 return token_ids, conditioning
@@ -678,5 +972,3 @@ class ModelRunner:
             if conditioning is not None:
                 return logits, conditioning
             return logits
-    
-

--- a/ssd/utils/loader.py
+++ b/ssd/utils/loader.py
@@ -5,20 +5,28 @@ from torch import nn
 from safetensors import safe_open
 from tqdm import tqdm
 
+
 def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
     param.data.copy_(loaded_weight)
 
 
-def load_embedding_from_target(model: nn.Module, target_path: str, target_hidden_size: int = None, draft_hidden_size: int = None) -> bool:
+def load_embedding_from_target(
+    model: nn.Module,
+    target_path: str,
+    target_hidden_size: int = None,
+    draft_hidden_size: int = None,
+) -> bool:
     """Try to load embedding weights from target model path (safetensors or bin)"""
     # Only load target embeddings if hidden sizes match (or if sizes not provided, assume compatible)
     if target_hidden_size is not None and draft_hidden_size is not None:
         if target_hidden_size != draft_hidden_size:
-            print(f"[load_model] Skipping target embeddings: target hidden_size={target_hidden_size} != draft hidden_size={draft_hidden_size}")
+            print(
+                f"[load_model] Skipping target embeddings: target hidden_size={target_hidden_size} != draft hidden_size={draft_hidden_size}"
+            )
             return False
-    
+
     target_keys = ["model.embed_tokens.weight", "embed_tokens.weight"]
-    
+
     # Try safetensors first
     safetensor_files = glob(os.path.join(target_path, "*.safetensors"))
     for file in safetensor_files:
@@ -31,7 +39,9 @@ def load_embedding_from_target(model: nn.Module, target_path: str, target_hidden
                         tensor = f.get_tensor(key)
                         # Always load into model.embed_tokens.weight for EAGLE
                         param = model.get_parameter("model.embed_tokens.weight")
-                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
                         weight_loader(param, tensor)
                         return True
         except Exception as e:
@@ -51,80 +61,103 @@ def load_embedding_from_target(model: nn.Module, target_path: str, target_hidden
                     print(f"[load_model] Found embedding {key} in {file}")
                     tensor = state_dict[key]
                     param = model.get_parameter("model.embed_tokens.weight")
-                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
                     weight_loader(param, tensor)
                     return True
         except Exception as e:
             print(f"[load_model] Error reading bin {file}: {e}")
             continue
-            
+
     return False
 
 
-def load_eagle_model(model: nn.Module, path: str, packed_modules_mapping: dict, target_path: str = None, target_hidden_size: int = None):
+def load_eagle_model(
+    model: nn.Module,
+    path: str,
+    packed_modules_mapping: dict,
+    target_path: str = None,
+    target_hidden_size: int = None,
+):
     """Load EAGLE3 draft model weights from safetensors or pytorch_model.bin"""
     # Try safetensors first
     safetensor_files = glob(os.path.join(path, "*.safetensors"))
     state_dict = None
-    
+
     if safetensor_files:
         print(f"[load_model] Detected EAGLE3 draft model, trying safetensors first")
-        # Load all safetensors into a single state dict
+        # Load all safetensors into a single state dict (handles sharded checkpoints)
         state_dict = {}
         for file in safetensor_files:
             try:
                 with safe_open(file, "pt", "cpu") as f:
                     for key in f.keys():
                         state_dict[key] = f.get_tensor(key)
-                print(f"[load_model] Loaded {len(state_dict)} weights from {file}")
-                break  # For EAGLE, typically just one file
+                print(
+                    f"[load_model] Loaded {len(state_dict)} cumulative weights (latest file: {file})"
+                )
             except Exception as e:
                 print(f"[load_model] Error reading safetensor {file}: {e}")
                 continue
-    
+
     # Fall back to pytorch_model.bin if safetensors didn't work
     if state_dict is None or len(state_dict) == 0:
         print(f"[load_model] Loading EAGLE3 draft model from pytorch_model.bin")
         bin_file = os.path.join(path, "pytorch_model.bin")
         if not os.path.exists(bin_file):
-            raise FileNotFoundError(f"No safetensors or pytorch_model.bin found at {path} for EAGLE3 draft model")
+            raise FileNotFoundError(
+                f"No safetensors or pytorch_model.bin found at {path} for EAGLE3 draft model"
+            )
         state_dict = torch.load(bin_file, map_location="cpu")
-    
+
     # Load d2t and t2d dictionaries
-    if hasattr(model, 'd2t') and 'd2t' in state_dict:
-        d2t_tensor = state_dict['d2t']
-        model.d2t = {i: int(d2t_tensor[i].item()) for i in range(len(d2t_tensor))}
-        model.d2t_tensor = d2t_tensor.to('cuda').long()  # keep as tensor for fast indexing
+    if hasattr(model, "d2t") and "d2t" in state_dict:
+        d2t_tensor = state_dict["d2t"]
+        d2t_values = d2t_tensor.to(dtype=torch.int64, device="cpu").tolist()
+        model.d2t = {i: value for i, value in enumerate(d2t_values)}
+        model.d2t_tensor = d2t_tensor.to(
+            "cuda"
+        ).long()  # keep as tensor for fast indexing
         print(f"[load_model] Loaded d2t dictionary with {len(model.d2t)} entries")
-    
-    if hasattr(model, 't2d') and 't2d' in state_dict:
-        t2d_tensor = state_dict['t2d']
-        model.t2d = {i: int(t2d_tensor[i].item()) for i in range(len(t2d_tensor))}
-        model.t2d_tensor = t2d_tensor.to('cuda').long()  # keep as tensor for fast indexing
+
+    if hasattr(model, "t2d") and "t2d" in state_dict:
+        t2d_tensor = state_dict["t2d"]
+        t2d_values = t2d_tensor.to(dtype=torch.int64, device="cpu").tolist()
+        model.t2d = {i: value for i, value in enumerate(t2d_values)}
+        model.t2d_tensor = t2d_tensor.to(
+            "cuda"
+        ).long()  # keep as tensor for fast indexing
         print(f"[load_model] Loaded t2d dictionary with {len(model.t2d)} entries")
-    
+
     # Check for embedding layer
     found_embed_tokens = False
     found_any_embed = False
     for weight_name in state_dict.keys():
-        if 'embed' in weight_name.lower():
+        if "embed" in weight_name.lower():
             found_any_embed = True
-            if 'embed_tokens' in weight_name:
+            if "embed_tokens" in weight_name:
                 found_embed_tokens = True
                 break
-    
+
     if not found_embed_tokens:
         if target_path and target_hidden_size is not None:
             draft_hidden_size = model.config.hidden_size
-            print(f"[load_model] 'embed_tokens' not found in draft weights. Attempting to load from target path: {target_path}")
-            if load_embedding_from_target(model, target_path, target_hidden_size, draft_hidden_size):
+            print(
+                f"[load_model] 'embed_tokens' not found in draft weights. Attempting to load from target path: {target_path}"
+            )
+            if load_embedding_from_target(
+                model, target_path, target_hidden_size, draft_hidden_size
+            ):
                 found_embed_tokens = True
         elif target_path:
             # For backward compatibility - if target_hidden_size not provided, try anyway (8B case)
-            print(f"[load_model] 'embed_tokens' not found in draft weights. Attempting to load from target path: {target_path}")
+            print(
+                f"[load_model] 'embed_tokens' not found in draft weights. Attempting to load from target path: {target_path}"
+            )
             if load_embedding_from_target(model, target_path):
                 found_embed_tokens = True
-        
+
         if not found_embed_tokens:
             if found_any_embed:
                 raise ValueError(
@@ -136,15 +169,19 @@ def load_eagle_model(model: nn.Module, path: str, packed_modules_mapping: dict, 
                     f"[load_model] ERROR: No embedding layer found in EAGLE3 weights. "
                     f"Expected 'embed_tokens' or similar. Available weights: {list(state_dict.keys())}"
                 )
-    
+
     # Load model weights
-    for weight_name, loaded_weight in tqdm(state_dict.items(), desc="Loading EAGLE3 weights"):
+    for weight_name, loaded_weight in tqdm(
+        state_dict.items(), desc="Loading EAGLE3 weights"
+    ):
         # Skip the dictionary tensors as we've already processed them
-        if weight_name in ['d2t', 't2d']:
+        if weight_name in ["d2t", "t2d"]:
             continue
-        
-        print(f'[load_model] loading weight {weight_name} with shape {loaded_weight.shape}')
-        
+
+        print(
+            f"[load_model] loading weight {weight_name} with shape {loaded_weight.shape}"
+        )
+
         # Check if this weight should use packed module loading
         is_packed = False
         for k, (v, shard_id) in packed_modules_mapping.items():
@@ -156,27 +193,27 @@ def load_eagle_model(model: nn.Module, path: str, packed_modules_mapping: dict, 
                 weight_loader(param, loaded_weight, shard_id)
                 is_packed = True
                 break
-        
+
         if is_packed:
             continue
-            
+
         # Map EAGLE3 weight names to our architecture for unpacked weights
-        if weight_name == 'midlayer.hidden_norm.weight':
+        if weight_name == "midlayer.hidden_norm.weight":
             # Special handling for conditioning feature layernorm
-            param_name = 'model.layer.conditioning_feature_ln.weight'
-        elif weight_name.startswith('midlayer.'):
+            param_name = "model.layer.conditioning_feature_ln.weight"
+        elif weight_name.startswith("midlayer."):
             # The single layer is stored in model.layer (not layers list) in our implementation
-            param_name = weight_name.replace('midlayer.', 'model.layer.')
-        elif weight_name == 'norm.weight':
+            param_name = weight_name.replace("midlayer.", "model.layer.")
+        elif weight_name == "norm.weight":
             # norm.weight -> final_norm.weight
-            param_name = 'final_norm.weight'
-        elif weight_name == 'embed_tokens.weight':
+            param_name = "final_norm.weight"
+        elif weight_name == "embed_tokens.weight":
             # embed_tokens.weight -> model.embed_tokens.weight
-            param_name = 'model.embed_tokens.weight'
+            param_name = "model.embed_tokens.weight"
         else:
             # fc.weight and lm_head.weight stay the same
             param_name = weight_name
-        
+
         # Load the parameter
         param = model.get_parameter(param_name)
         weight_loader = getattr(param, "weight_loader", default_weight_loader)
@@ -199,19 +236,29 @@ def load_safetensors_model(model: nn.Module, path: str, packed_modules_mapping: 
                         break
                 else:
                     param = model.get_parameter(weight_name)
-                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
                     weight_loader(param, f.get_tensor(weight_name))
 
 
-def load_model(model: nn.Module, path: str, target_path: str = None, target_hidden_size: int = None):
+def load_model(
+    model: nn.Module, path: str, target_path: str = None, target_hidden_size: int = None
+):
     print(f"[load_model] loading model from {path}")
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
-    
+
     # Check if this is an EAGLE3 draft model
-    is_eagle = 'eagle' in path.lower()
-    
+    is_eagle = "eagle" in path.lower()
+
     if is_eagle:
-        load_eagle_model(model, path, packed_modules_mapping, target_path=target_path, target_hidden_size=target_hidden_size)
+        load_eagle_model(
+            model,
+            path,
+            packed_modules_mapping,
+            target_path=target_path,
+            target_hidden_size=target_hidden_size,
+        )
     else:
         load_safetensors_model(model, path, packed_modules_mapping)
 


### PR DESCRIPTION
## Summary
- keep loading all available EAGLE safetensor shards instead of stopping after the first file
- normalize `d2t`/`t2d` tensor conversion through CPU lists before rebuilding the Python dictionaries
- tighten the embedding fallback and loader logging path so the EAGLE import path fails more predictably

## Testing
- `python3 -m py_compile ssd/utils/loader.py`