### PR TITLE
fix: prefer SSD_DATASET_DIR for dataset bootstrap

### DIFF
--- a/scripts/get_data_from_hf.py
+++ b/scripts/get_data_from_hf.py
@@ -4,24 +4,29 @@ from datasets import load_dataset
 
 
 def get_base_output_dir():
-    """Get base output directory from HF_DATASETS_CACHE or default."""
-    hf_cache = os.environ.get('HF_DATASETS_CACHE', '/tmp/hf_datasets_cache')
+    """Get base output directory from SSD_DATASET_DIR, HF_DATASETS_CACHE, or default."""
+    dataset_dir = os.environ.get("SSD_DATASET_DIR")
+    if dataset_dir:
+        print(f"Using SSD_DATASET_DIR: {dataset_dir}")
+        return dataset_dir
+
+    hf_cache = os.environ.get("HF_DATASETS_CACHE", "/tmp/hf_datasets_cache")
     print(f"Using HF_DATASETS_CACHE: {hf_cache}")
-    return os.path.join(hf_cache, 'processed_datasets')
+    return os.path.join(hf_cache, "processed_datasets")
 
 
 def download_gsm8k_data(num_samples=None):
     """Download GSM8K dataset samples and save as JSONL."""
     output_dir = os.path.join(get_base_output_dir(), "gsm8k")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Limit to 10k samples max
     max_samples = 10000
     if num_samples is None:
         num_samples = max_samples
     else:
         num_samples = min(num_samples, max_samples)
-    
+
     output_file = os.path.join(output_dir, f"gsm8k_data_{num_samples}.jsonl")
 
     if os.path.exists(output_file):
@@ -29,7 +34,7 @@ def download_gsm8k_data(num_samples=None):
         return output_file
 
     print(f"Loading GSM8K dataset...")
-    
+
     try:
         dataset = load_dataset("openai/gsm8k", "main", split="train")
     except Exception as e:
@@ -38,14 +43,16 @@ def download_gsm8k_data(num_samples=None):
 
     total_samples = len(dataset)
     samples_to_process = min(num_samples, total_samples)
-    
-    print(f"Processing {samples_to_process} samples from {total_samples} total samples...")
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    print(
+        f"Processing {samples_to_process} samples from {total_samples} total samples..."
+    )
+
+    with open(output_file, "w", encoding="utf-8") as f:
         for i in range(samples_to_process):
             example = dataset[i]
-            sample = {"text": example['question']}
-            f.write(json.dumps(sample) + '\n')
+            sample = {"text": example["question"]}
+            f.write(json.dumps(sample) + "\n")
 
             if i % 500 == 0:
                 print(f"Processed {i}/{samples_to_process} samples...")
@@ -58,14 +65,14 @@ def download_c4_data(num_samples=None):
     """Download C4 dataset samples and save as JSONL."""
     output_dir = os.path.join(get_base_output_dir(), "c4")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Limit to 10k samples max
     max_samples = 10000
     if num_samples is None:
         num_samples = max_samples
     else:
         num_samples = min(num_samples, max_samples)
-    
+
     output_file = os.path.join(output_dir, f"c4_data_{num_samples}.jsonl")
 
     if os.path.exists(output_file):
@@ -73,7 +80,7 @@ def download_c4_data(num_samples=None):
         return output_file
 
     print(f"Loading C4 dataset...")
-    
+
     try:
         dataset = load_dataset("allenai/c4", "en", split="train", streaming=True)
     except Exception as e:
@@ -82,18 +89,19 @@ def download_c4_data(num_samples=None):
 
     print(f"Processing C4 samples (streaming)...")
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    i = -1
+    with open(output_file, "w", encoding="utf-8") as f:
         for i, example in enumerate(dataset):
             if i >= num_samples:
                 break
-                
-            sample = {"text": example['text']}
-            f.write(json.dumps(sample) + '\n')
+
+            sample = {"text": example["text"]}
+            f.write(json.dumps(sample) + "\n")
 
             if i % 1000 == 0:
                 print(f"Processed {i} samples...")
 
-    samples_processed = min(i + 1, num_samples) if 'i' in locals() else 0
+    samples_processed = min(i + 1, num_samples) if i >= 0 else 0
     print(f"Saved {samples_processed} C4 samples to {output_file}")
     return output_file
 
@@ -102,14 +110,14 @@ def download_ultrafeedback_data(num_samples=None):
     """Download UltraFeedback dataset samples and save as JSONL."""
     output_dir = os.path.join(get_base_output_dir(), "ultrafeedback")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Limit to 10k samples max
     max_samples = 10000
     if num_samples is None:
         num_samples = max_samples
     else:
         num_samples = min(num_samples, max_samples)
-    
+
     output_file = os.path.join(output_dir, f"ultrafeedback_data_{num_samples}.jsonl")
 
     if os.path.exists(output_file):
@@ -117,7 +125,7 @@ def download_ultrafeedback_data(num_samples=None):
         return output_file
 
     print(f"Loading UltraFeedback dataset...")
-    
+
     try:
         dataset = load_dataset("openbmb/UltraFeedback", split="train")
     except Exception as e:
@@ -126,15 +134,17 @@ def download_ultrafeedback_data(num_samples=None):
 
     total_samples = len(dataset)
     samples_to_process = min(num_samples, total_samples)
-    
-    print(f"Processing {samples_to_process} samples from {total_samples} total samples...")
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    print(
+        f"Processing {samples_to_process} samples from {total_samples} total samples..."
+    )
+
+    with open(output_file, "w", encoding="utf-8") as f:
         for i in range(samples_to_process):
             example = dataset[i]
             # Use the instruction field as the main text
-            sample = {"text": example['instruction']}
-            f.write(json.dumps(sample) + '\n')
+            sample = {"text": example["instruction"]}
+            f.write(json.dumps(sample) + "\n")
 
             if i % 500 == 0:
                 print(f"Processed {i}/{samples_to_process} samples...")
@@ -147,14 +157,14 @@ def download_humaneval_data(num_samples=None):
     """Download OpenAI HumanEval dataset samples and save as JSONL."""
     output_dir = os.path.join(get_base_output_dir(), "humaneval")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Limit to 10k samples max
     max_samples = 10000
     if num_samples is None:
         num_samples = max_samples
     else:
         num_samples = min(num_samples, max_samples)
-    
+
     output_file = os.path.join(output_dir, f"humaneval_data_{num_samples}.jsonl")
 
     if os.path.exists(output_file):
@@ -162,7 +172,7 @@ def download_humaneval_data(num_samples=None):
         return output_file
 
     print(f"Loading HumanEval dataset...")
-    
+
     try:
         dataset = load_dataset("openai/openai_humaneval", split="test")
     except Exception as e:
@@ -171,15 +181,17 @@ def download_humaneval_data(num_samples=None):
 
     total_samples = len(dataset)
     samples_to_process = min(num_samples, total_samples)
-    
-    print(f"Processing {samples_to_process} samples from {total_samples} total samples...")
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    print(
+        f"Processing {samples_to_process} samples from {total_samples} total samples..."
+    )
+
+    with open(output_file, "w", encoding="utf-8") as f:
         for i in range(samples_to_process):
             example = dataset[i]
             # Use the prompt field as the main text
-            sample = {"text": example['prompt']}
-            f.write(json.dumps(sample) + '\n')
+            sample = {"text": example["prompt"]}
+            f.write(json.dumps(sample) + "\n")
 
             if i % 100 == 0:
                 print(f"Processed {i}/{samples_to_process} samples...")
@@ -192,14 +204,14 @@ def download_alpaca_data(num_samples=None):
     """Download Alpaca dataset samples and save as JSONL."""
     output_dir = os.path.join(get_base_output_dir(), "alpaca")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Limit to 10k samples max
     max_samples = 10000
     if num_samples is None:
         num_samples = max_samples
     else:
         num_samples = min(num_samples, max_samples)
-    
+
     output_file = os.path.join(output_dir, f"alpaca_data_{num_samples}.jsonl")
 
     if os.path.exists(output_file):
@@ -207,7 +219,7 @@ def download_alpaca_data(num_samples=None):
         return output_file
 
     print(f"Loading Alpaca dataset...")
-    
+
     try:
         dataset = load_dataset("tatsu-lab/alpaca", split="train")
     except Exception as e:
@@ -216,19 +228,21 @@ def download_alpaca_data(num_samples=None):
 
     total_samples = len(dataset)
     samples_to_process = min(num_samples, total_samples)
-    
-    print(f"Processing {samples_to_process} samples from {total_samples} total samples...")
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    print(
+        f"Processing {samples_to_process} samples from {total_samples} total samples..."
+    )
+
+    with open(output_file, "w", encoding="utf-8") as f:
         for i in range(samples_to_process):
             example = dataset[i]
             # Combine instruction and input if available, otherwise just instruction
-            text = example['instruction']
-            if example.get('input', '').strip():
+            text = example["instruction"]
+            if example.get("input", "").strip():
                 text = f"{text}\n\n{example['input']}"
-            
+
             sample = {"text": text}
-            f.write(json.dumps(sample) + '\n')
+            f.write(json.dumps(sample) + "\n")
 
             if i % 500 == 0:
                 print(f"Processed {i}/{samples_to_process} samples...")
@@ -240,7 +254,7 @@ def download_alpaca_data(num_samples=None):
 def download_all_datasets(num_samples=None):
     """Download all datasets."""
     print("Downloading all datasets...")
-    
+
     datasets = [
         ("GSM8K", download_gsm8k_data),
         ("C4", download_c4_data),
@@ -248,13 +262,13 @@ def download_all_datasets(num_samples=None):
         ("HumanEval", download_humaneval_data),
         ("Alpaca", download_alpaca_data),
     ]
-    
+
     output_files = {}
     for name, download_func in datasets:
-        print(f"\n{'='*50}")
+        print(f"\n{'=' * 50}")
         print(f"Downloading {name}...")
-        print('='*50)
-        
+        print("=" * 50)
+
         try:
             output_file = download_func(num_samples)
             output_files[name] = output_file
@@ -262,24 +276,28 @@ def download_all_datasets(num_samples=None):
         except Exception as e:
             print(f"✗ Failed to download {name}: {e}")
             output_files[name] = None
-    
+
     return output_files
 
 
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Download datasets from Hugging Face")
-    parser.add_argument("--num-samples", type=int, default=None, 
-                       help="Number of samples to download (default: all)")
-    
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=None,
+        help="Number of samples to download (default: all)",
+    )
+
     args = parser.parse_args()
-    
+
     output_files = download_all_datasets(args.num_samples)
-    
-    print(f"\n{'='*60}")
+
+    print(f"\n{'=' * 60}")
     print("Download Summary:")
-    print('='*60)
+    print("=" * 60)
     for name, file_path in output_files.items():
         if file_path:
             print(f"✓ {name}: {file_path}")

--- a/tests/test_get_data_from_hf_paths.py
+++ b/tests/test_get_data_from_hf_paths.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "get_data_from_hf.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "get_data_from_hf_under_test", MODULE_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class GetDataFromHFPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_datasets = sys.modules.get("datasets")
+        fake = types.ModuleType("datasets")
+        fake.load_dataset = lambda *args, **kwargs: None
+        sys.modules["datasets"] = fake
+
+    def tearDown(self) -> None:
+        if self.original_datasets is None:
+            sys.modules.pop("datasets", None)
+        else:
+            sys.modules["datasets"] = self.original_datasets
+
+    def test_get_base_output_dir_prefers_ssd_dataset_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            previous_dataset = os.environ.get("SSD_DATASET_DIR")
+            previous_hf = os.environ.get("HF_DATASETS_CACHE")
+            os.environ["SSD_DATASET_DIR"] = tmp
+            os.environ["HF_DATASETS_CACHE"] = "/tmp/hf-should-not-win"
+            try:
+                module = load_module()
+                self.assertEqual(module.get_base_output_dir(), tmp)
+            finally:
+                if previous_dataset is None:
+                    os.environ.pop("SSD_DATASET_DIR", None)
+                else:
+                    os.environ["SSD_DATASET_DIR"] = previous_dataset
+                if previous_hf is None:
+                    os.environ.pop("HF_DATASETS_CACHE", None)
+                else:
+                    os.environ["HF_DATASETS_CACHE"] = previous_hf
+
+    def test_get_base_output_dir_falls_back_to_hf_cache(self) -> None:
+        previous_dataset = os.environ.pop("SSD_DATASET_DIR", None)
+        previous_hf = os.environ.get("HF_DATASETS_CACHE")
+        os.environ["HF_DATASETS_CACHE"] = "/tmp/hf-cache-root"
+        try:
+            module = load_module()
+            self.assertEqual(
+                module.get_base_output_dir(), "/tmp/hf-cache-root/processed_datasets"
+            )
+        finally:
+            if previous_dataset is not None:
+                os.environ["SSD_DATASET_DIR"] = previous_dataset
+            if previous_hf is None:
+                os.environ.pop("HF_DATASETS_CACHE", None)
+            else:
+                os.environ["HF_DATASETS_CACHE"] = previous_hf
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make dataset bootstrap respect `SSD_DATASET_DIR` before falling back to `HF_DATASETS_CACHE`
- keep generated JSONL files in the same processed-dataset directory that SSD runtime commands already expect
- add focused path resolution tests for both the preferred and fallback cases

## End-user benefit
People who already set `SSD_DATASET_DIR` to point at their processed dataset directory no longer end up writing fresh bootstrap output to a different path under `HF_DATASETS_CACHE`. That removes a confusing mismatch where downloads appeared to succeed but benchmark/chat commands still looked in a different directory.

## Testing
- `python -m unittest tests.test_get_data_from_hf_paths`
- `python -m py_compile scripts/get_data_from_hf.py tests/test_get_data_from_hf_paths.py`