### PR TITLE
fix: avoid killing unrelated benchmark servers

### DIFF
--- a/bench/chat.py
+++ b/bench/chat.py
@@ -7,10 +7,12 @@ Usage:
     python chat.py --vllm [--ar]
     python chat.py --sglang --url http://localhost:40010
 """
+
 import os, sys, time, json, signal, argparse, subprocess, multiprocessing as mp
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import HF_CACHE_DIR, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 TARGET = resolve_snapshot(f"{HF_CACHE_DIR}/models--meta-llama--Llama-3.1-70B-Instruct")
 DRAFT = resolve_snapshot(f"{HF_CACHE_DIR}/models--meta-llama--Llama-3.2-1B-Instruct")
@@ -35,8 +37,16 @@ def parse_args():
     p.add_argument("--b", type=int, default=1)
     p.add_argument("--x", type=float, default=None)
     p.add_argument("--eager", action="store_true")
-    p.add_argument("--ignore_eos", action="store_true", help="Ignore EOS token (generate full output_len)")
-    p.add_argument("--metrics", action="store_true", help="Print token count, speed, TTFT after each response")
+    p.add_argument(
+        "--ignore_eos",
+        action="store_true",
+        help="Ignore EOS token (generate full output_len)",
+    )
+    p.add_argument(
+        "--metrics",
+        action="store_true",
+        help="Print token count, speed, TTFT after each response",
+    )
     # Server
     p.add_argument("--tp", type=int, default=4)
     p.add_argument("--port", type=int, default=None)
@@ -53,7 +63,7 @@ def _decode_worker(conn, tokenizer):
             break
         ids.extend(chunk)
         full = tokenizer.decode(ids, skip_special_tokens=True)
-        delta = full[len(prev):]
+        delta = full[len(prev) :]
         if delta:
             print(delta, end="", flush=True)
         prev = full
@@ -66,12 +76,21 @@ def ssd_chat(args):
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
     tokenizer = AutoTokenizer.from_pretrained(TARGET)
-    llm = LLM(TARGET, enforce_eager=args.eager, num_gpus=args.gpus,
-              speculate=args.spec, speculate_k=args.k,
-              draft_async=args.async_spec, async_fan_out=args.f,
-              draft=DRAFT, kvcache_block_size=256, max_num_seqs=args.b,
-              max_model_len=8192, sampler_x=args.x,
-              jit_speculate=(args.backup == "jit"))
+    llm = LLM(
+        TARGET,
+        enforce_eager=args.eager,
+        num_gpus=args.gpus,
+        speculate=args.spec,
+        speculate_k=args.k,
+        draft_async=args.async_spec,
+        async_fan_out=args.f,
+        draft=DRAFT,
+        kvcache_block_size=256,
+        max_num_seqs=args.b,
+        max_model_len=8192,
+        sampler_x=args.x,
+        jit_speculate=(args.backup == "jit"),
+    )
 
     history = []
     print(f"\nChat via SSD. Type 'quit' to exit.\n")
@@ -79,27 +98,40 @@ def ssd_chat(args):
         try:
             user_input = input("User: ")
         except (EOFError, KeyboardInterrupt):
-            print(); break
+            print()
+            break
         if user_input.strip().lower() in ("quit", "exit", "q"):
             break
 
         history.append({"role": "user", "content": user_input})
-        token_ids = tokenizer.apply_chat_template(history, add_generation_prompt=True, tokenize=True)
-        sp = SamplingParams(temperature=args.temp, max_new_tokens=args.output_len, ignore_eos=args.ignore_eos)
+        token_ids = tokenizer.apply_chat_template(
+            history, add_generation_prompt=True, tokenize=True
+        )
+        sp = SamplingParams(
+            temperature=args.temp,
+            max_new_tokens=args.output_len,
+            ignore_eos=args.ignore_eos,
+        )
 
         parent_conn, child_conn = mp.Pipe()
-        proc = mp.Process(target=_decode_worker, args=(child_conn, tokenizer), daemon=True)
+        proc = mp.Process(
+            target=_decode_worker, args=(child_conn, tokenizer), daemon=True
+        )
         proc.start()
         child_conn.close()
 
         t_first = [None]
+
         def on_tokens(seq_id, new_ids):
-            if t_first[0] is None: t_first[0] = time.time()
+            if t_first[0] is None:
+                t_first[0] = time.time()
             parent_conn.send(list(new_ids))
 
         print("Assistant: ", end="", flush=True)
         t0 = time.time()
-        outputs, _ = llm.generate([token_ids], [sp], use_tqdm=False, stream_callback=on_tokens)
+        outputs, _ = llm.generate(
+            [token_ids], [sp], use_tqdm=False, stream_callback=on_tokens
+        )
         t_end = time.time()
         parent_conn.send(None)
         proc.join(timeout=5)
@@ -108,17 +140,21 @@ def ssd_chat(args):
         ttft = (t_first[0] - t0) if t_first[0] else 0
         dt = t_end - (t_first[0] or t0)
         if args.metrics:
-            print(f"\n  [{n} tok, {n/dt:.0f} tok/s, {ttft:.2f}s TTFT]")
+            print(f"\n  [{n} tok, {n / dt:.0f} tok/s, {ttft:.2f}s TTFT]")
         print()
         history.append({"role": "assistant", "content": outputs[0]["text"]})
 
 
 def wait_for_server(port, timeout=900, interval=5):
     import requests
+
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            if requests.get(f"http://localhost:{port}/health", timeout=2).status_code == 200:
+            if (
+                requests.get(f"http://localhost:{port}/health", timeout=2).status_code
+                == 200
+            ):
                 return True
         except (requests.ConnectionError, requests.Timeout):
             pass
@@ -129,6 +165,7 @@ def wait_for_server(port, timeout=900, interval=5):
 def server_chat(args):
     import requests
     from transformers import AutoTokenizer
+
     tokenizer = AutoTokenizer.from_pretrained(TARGET)
 
     backend = "sglang" if args.sglang else "vllm"
@@ -139,34 +176,74 @@ def server_chat(args):
         base_url = args.url.rstrip("/")
     else:
         if args.sglang:
-            cmd = [sys.executable, "-m", "sglang.launch_server",
-                   "--model-path", TARGET, "--tp", str(args.tp),
-                   "--mem-fraction-static", "0.70", "--max-running-requests", "1",
-                   "--disable-radix-cache", "--log-level", "warning",
-                   "--port", str(port)]
+            cmd = [
+                sys.executable,
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                TARGET,
+                "--tp",
+                str(args.tp),
+                "--mem-fraction-static",
+                "0.70",
+                "--max-running-requests",
+                "1",
+                "--disable-radix-cache",
+                "--log-level",
+                "warning",
+                "--port",
+                str(port),
+            ]
             if not args.ar:
-                cmd += ["--speculative-algorithm", "STANDALONE",
-                        "--speculative-draft-model-path", DRAFT,
-                        "--speculative-num-steps", "4",
-                        "--speculative-eagle-topk", "1",
-                        "--speculative-num-draft-tokens", "5"]
+                cmd += [
+                    "--speculative-algorithm",
+                    "STANDALONE",
+                    "--speculative-draft-model-path",
+                    DRAFT,
+                    "--speculative-num-steps",
+                    "4",
+                    "--speculative-eagle-topk",
+                    "1",
+                    "--speculative-num-draft-tokens",
+                    "5",
+                ]
         else:
-            cmd = [sys.executable, "-m", "vllm.entrypoints.openai.api_server",
-                   "--model", TARGET, "--tensor-parallel-size", str(args.tp),
-                   "--gpu-memory-utilization", "0.90", "--max-num-seqs", "1",
-                   "--disable-log-requests", "--disable-log-stats", "--port", str(port)]
+            cmd = [
+                sys.executable,
+                "-m",
+                "vllm.entrypoints.openai.api_server",
+                "--model",
+                TARGET,
+                "--tensor-parallel-size",
+                str(args.tp),
+                "--gpu-memory-utilization",
+                "0.90",
+                "--max-num-seqs",
+                "1",
+                "--disable-log-requests",
+                "--disable-log-stats",
+                "--port",
+                str(port),
+            ]
             if not args.ar:
-                spec = {"model": DRAFT, "num_speculative_tokens": 5, "method": "draft_model"}
+                spec = {
+                    "model": DRAFT,
+                    "num_speculative_tokens": 5,
+                    "method": "draft_model",
+                }
                 cmd += ["--speculative-config", json.dumps(spec)]
 
-        subprocess.run(["pkill", "-9", "-f",
-                        "sglang.launch_server" if args.sglang else "vllm.entrypoints"],
-                       capture_output=True)
-        time.sleep(2)
+        ensure_port_available(port, backend)
         print(f"Launching {backend}...")
-        proc = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        proc = subprocess.Popen(
+            cmd,
+            preexec_fn=os.setsid,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         if not wait_for_server(port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Ready.")
         base_url = f"http://localhost:{port}"
 
@@ -178,40 +255,56 @@ def server_chat(args):
             try:
                 user_input = input("User: ")
             except (EOFError, KeyboardInterrupt):
-                print(); break
+                print()
+                break
             if user_input.strip().lower() in ("quit", "exit", "q"):
                 break
 
             history.append({"role": "user", "content": user_input})
-            token_ids = tokenizer.apply_chat_template(history, add_generation_prompt=True, tokenize=True)
-            payload = {"model": TARGET, "prompt": token_ids,
-                       "temperature": args.temp, "max_tokens": args.output_len,
-                       "stream": True, "stream_options": {"include_usage": True}}
+            token_ids = tokenizer.apply_chat_template(
+                history, add_generation_prompt=True, tokenize=True
+            )
+            payload = {
+                "model": TARGET,
+                "prompt": token_ids,
+                "temperature": args.temp,
+                "max_tokens": args.output_len,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
 
             print("Assistant: ", end="", flush=True)
             t0 = time.time()
-            resp = requests.post(f"{base_url}/v1/completions", json=payload, stream=True)
+            resp = requests.post(
+                f"{base_url}/v1/completions", json=payload, stream=True
+            )
             resp.raise_for_status()
 
             full, t_first, usage = "", None, {}
             for line in resp.iter_lines(decode_unicode=True):
-                if not line or not line.startswith("data: "): continue
+                if not line or not line.startswith("data: "):
+                    continue
                 data = line[6:]
-                if data.strip() == "[DONE]": break
+                if data.strip() == "[DONE]":
+                    break
                 chunk = json.loads(data)
-                delta = chunk["choices"][0].get("text", "") if chunk.get("choices") else ""
+                delta = (
+                    chunk["choices"][0].get("text", "") if chunk.get("choices") else ""
+                )
                 if delta:
-                    if t_first is None: t_first = time.time()
+                    if t_first is None:
+                        t_first = time.time()
                     full += delta
                     print(delta, end="", flush=True)
-                if "usage" in chunk: usage = chunk["usage"]
+                if "usage" in chunk:
+                    usage = chunk["usage"]
 
             t_end = time.time()
             n = usage.get("completion_tokens", len(full.split()))
             ttft = (t_first - t0) if t_first else 0
             dt = t_end - (t_first or t0)
             if args.metrics:
-                print(f"\n  [{n} tok, {n/dt:.0f} tok/s, {ttft:.2f}s TTFT]")
+                print(f"\n  [{n} tok, {n / dt:.0f} tok/s, {ttft:.2f}s TTFT]")
             print()
             history.append({"role": "assistant", "content": full})
     finally:

--- a/bench/run_sglang_bench.py
+++ b/bench/run_sglang_bench.py
@@ -11,6 +11,7 @@ Usage:
 
 Set model paths via env vars (BENCH_LLAMA_70B, etc.) or edit bench_paths.py.
 """
+
 import os
 import sys
 import time
@@ -21,6 +22,7 @@ import requests
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import MODELS, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 
 def get_server_cmd(args):
@@ -32,25 +34,38 @@ def get_server_cmd(args):
         draft = resolve_snapshot(MODELS["qwen_0.6b"])
 
     cmd = [
-        sys.executable, "-m", "sglang.launch_server",
-        "--model-path", target,
-        "--tp", str(args.tp),
-        "--mem-fraction-static", str(args.mem_frac),
-        "--max-running-requests", "1",
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        target,
+        "--tp",
+        str(args.tp),
+        "--mem-fraction-static",
+        str(args.mem_frac),
+        "--max-running-requests",
+        "1",
         "--disable-radix-cache",
-        "--log-level", "warning",
-        "--port", str(args.port),
+        "--log-level",
+        "warning",
+        "--port",
+        str(args.port),
     ]
 
     if args.mode == "sd":
         # Speculative decoding with standalone draft model.
         # Default: k=5 (num_steps=4, num_draft_tokens=5).
         cmd += [
-            "--speculative-algorithm", "STANDALONE",
-            "--speculative-draft-model-path", draft,
-            "--speculative-num-steps", str(args.num_steps),
-            "--speculative-eagle-topk", "1",
-            "--speculative-num-draft-tokens", str(args.num_draft_tokens),
+            "--speculative-algorithm",
+            "STANDALONE",
+            "--speculative-draft-model-path",
+            draft,
+            "--speculative-num-steps",
+            str(args.num_steps),
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            str(args.num_draft_tokens),
         ]
     # mode == "ar": no speculative flags, just serve the target model.
 
@@ -77,15 +92,23 @@ def kill_server(proc):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Launch SGLang server and benchmark it")
+    parser = argparse.ArgumentParser(
+        description="Launch SGLang server and benchmark it"
+    )
     parser.add_argument("--llama", action="store_true", default=True)
     parser.add_argument("--qwen", action="store_true")
-    parser.add_argument("--mode", choices=["ar", "sd"], default="sd",
-                        help="ar = autoregressive, sd = speculative decoding (default)")
+    parser.add_argument(
+        "--mode",
+        choices=["ar", "sd"],
+        default="sd",
+        help="ar = autoregressive, sd = speculative decoding (default)",
+    )
     parser.add_argument("--tp", type=int, default=4)
     parser.add_argument("--port", type=int, default=40010)
     parser.add_argument("--mem_frac", type=float, default=0.70)
-    parser.add_argument("--num_steps", type=int, default=4, help="draft chain depth (k = num_steps + 1)")
+    parser.add_argument(
+        "--num_steps", type=int, default=4, help="draft chain depth (k = num_steps + 1)"
+    )
     parser.add_argument("--num_draft_tokens", type=int, default=5)
     # Pass-through to eval client
     parser.add_argument("--numseqs", type=int, default=128)
@@ -102,28 +125,34 @@ def main():
     print(f"Mode: {args.mode}, Target: {target}")
     print(f"Server cmd: {' '.join(server_cmd)}")
 
-    # Kill stale sglang processes
-    subprocess.run(["pkill", "-9", "-f", "sglang.launch_server"],
-                   capture_output=True)
-    time.sleep(2)
+    ensure_port_available(args.port, "SGLang")
 
     proc = subprocess.Popen(server_cmd, preexec_fn=os.setsid)
     try:
         print("Waiting for server...")
         if not wait_for_server(args.port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Server ready")
 
         # Build eval client command
         bench_dir = os.path.dirname(__file__)
         eval_cmd = [
-            sys.executable, os.path.join(bench_dir, "sglang_eval_client.py"),
-            "--size", "70" if args.llama else "32",
-            "--numseqs", str(args.numseqs),
-            "--output_len", str(args.output_len),
-            "--temp", str(args.temp),
-            "--all", "--b", "1",
-            "--port", str(args.port),
+            sys.executable,
+            os.path.join(bench_dir, "sglang_eval_client.py"),
+            "--size",
+            "70" if args.llama else "32",
+            "--numseqs",
+            str(args.numseqs),
+            "--output_len",
+            str(args.output_len),
+            "--temp",
+            str(args.temp),
+            "--all",
+            "--b",
+            "1",
+            "--port",
+            str(args.port),
         ]
         if args.llama:
             eval_cmd.append("--llama")

--- a/bench/run_vllm_bench.py
+++ b/bench/run_vllm_bench.py
@@ -11,6 +11,7 @@ Usage:
 
 Set model paths via env vars (BENCH_LLAMA_70B, etc.) or edit bench_paths.py.
 """
+
 import os
 import sys
 import json
@@ -22,6 +23,7 @@ import requests
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_paths import MODELS, resolve_snapshot
+from server_lifecycle import ensure_port_available
 
 
 def get_server_cmd(args):
@@ -33,13 +35,20 @@ def get_server_cmd(args):
         draft = resolve_snapshot(MODELS["qwen_0.6b"])
 
     cmd = [
-        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
-        "--model", target,
-        "--tensor-parallel-size", str(args.tp),
-        "--gpu-memory-utilization", str(args.mem_frac),
-        "--max-num-seqs", "1",
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        target,
+        "--tensor-parallel-size",
+        str(args.tp),
+        "--gpu-memory-utilization",
+        str(args.mem_frac),
+        "--max-num-seqs",
+        "1",
         "--disable-log-requests",
-        "--port", str(args.port),
+        "--port",
+        str(args.port),
     ]
 
     if args.mode == "sd":
@@ -78,8 +87,12 @@ def main():
     parser = argparse.ArgumentParser(description="Launch vLLM server and benchmark it")
     parser.add_argument("--llama", action="store_true", default=True)
     parser.add_argument("--qwen", action="store_true")
-    parser.add_argument("--mode", choices=["ar", "sd"], default="sd",
-                        help="ar = autoregressive, sd = speculative decoding (default)")
+    parser.add_argument(
+        "--mode",
+        choices=["ar", "sd"],
+        default="sd",
+        help="ar = autoregressive, sd = speculative decoding (default)",
+    )
     parser.add_argument("--tp", type=int, default=4)
     parser.add_argument("--port", type=int, default=40020)
     parser.add_argument("--mem_frac", type=float, default=0.90)
@@ -99,27 +112,33 @@ def main():
     print(f"Mode: {args.mode}, Target: {target}")
     print(f"Server cmd: {' '.join(server_cmd)}")
 
-    # Kill stale vllm processes
-    subprocess.run(["pkill", "-9", "-f", "vllm.entrypoints"],
-                   capture_output=True)
-    time.sleep(2)
+    ensure_port_available(args.port, "vLLM")
 
     proc = subprocess.Popen(server_cmd, preexec_fn=os.setsid)
     try:
         print("Waiting for server...")
         if not wait_for_server(args.port):
-            print("Server failed to start"); sys.exit(1)
+            print("Server failed to start")
+            sys.exit(1)
         print("Server ready")
 
         bench_dir = os.path.dirname(__file__)
         eval_cmd = [
-            sys.executable, os.path.join(bench_dir, "vllm_eval_client.py"),
-            "--size", "70" if args.llama else "32",
-            "--numseqs", str(args.numseqs),
-            "--output_len", str(args.output_len),
-            "--temp", str(args.temp),
-            "--all", "--b", "1",
-            "--port", str(args.port),
+            sys.executable,
+            os.path.join(bench_dir, "vllm_eval_client.py"),
+            "--size",
+            "70" if args.llama else "32",
+            "--numseqs",
+            str(args.numseqs),
+            "--output_len",
+            str(args.output_len),
+            "--temp",
+            str(args.temp),
+            "--all",
+            "--b",
+            "1",
+            "--port",
+            str(args.port),
         ]
         if args.llama:
             eval_cmd.append("--llama")

--- a/bench/server_lifecycle.py
+++ b/bench/server_lifecycle.py
@@ -1,0 +1,14 @@
+import socket
+
+
+def is_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
+
+
+def ensure_port_available(port: int, service_name: str) -> None:
+    if is_port_in_use(port):
+        raise RuntimeError(
+            f"Port {port} is already in use. Stop the existing {service_name} server or choose a different --port before launching a new benchmark."
+        )

--- a/bench/test_server_lifecycle.py
+++ b/bench/test_server_lifecycle.py
@@ -1,0 +1,36 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bench.server_lifecycle import ensure_port_available, is_port_in_use
+
+
+class ServerLifecycleTests(unittest.TestCase):
+    @patch("bench.server_lifecycle.socket.socket")
+    def test_is_port_in_use_true_when_connect_succeeds(self, socket_cls):
+        sock = socket_cls.return_value.__enter__.return_value
+        sock.connect_ex.return_value = 0
+
+        self.assertTrue(is_port_in_use(40020))
+
+    @patch("bench.server_lifecycle.socket.socket")
+    def test_is_port_in_use_false_when_connect_fails(self, socket_cls):
+        sock = socket_cls.return_value.__enter__.return_value
+        sock.connect_ex.return_value = 111
+
+        self.assertFalse(is_port_in_use(40020))
+
+    @patch("bench.server_lifecycle.is_port_in_use", return_value=True)
+    def test_ensure_port_available_raises_for_busy_port(self, _port_check):
+        with self.assertRaises(RuntimeError) as error:
+            ensure_port_available(40020, "vLLM")
+
+        self.assertIn("Port 40020 is already in use", str(error.exception))
+        self.assertIn("different --port", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the benchmark scripts' global kill behavior with an explicit port-availability guard
- fail fast with a clear error when the requested backend port is already occupied instead of terminating unrelated vLLM/SGLang servers on the machine
- add focused lifecycle tests for the shared port-check helper

## End-user benefit
When someone already has a backend server running on the chosen benchmark port, the current scripts can kill that unrelated process before starting a new run. This change preserves the existing server, reports the port conflict clearly, and lets the user pick a different `--port` instead of losing an in-flight workload.

## Testing
- `python -m unittest bench.test_server_lifecycle -v`
- `python -m py_compile bench/server_lifecycle.py bench/run_vllm_bench.py bench/run_sglang_bench.py bench/chat.py bench/test_server_lifecycle.py`