### PR TITLE
delete write_shm 

### DIFF
--- a/ssd/engine/model_runner.py
+++ b/ssd/engine/model_runner.py
@@ -420,7 +420,7 @@ class ModelRunner:
             event.set()
 
     def call(self, method_name, *args):
-        if self.world_size > 1 and self.rank == 0:
+        if self.num_tp_gpus > 1 and self.rank == 0:
             self.write_shm(method_name, *args)
         method = getattr(self, method_name, None)
         if method is None:


### PR DESCRIPTION
When num_tp_gpus=1 (e.g., num_gpus=2 with draft_async=True), there are no TP worker processes to consume the shared memory, so write_shm is unnecessary. However, the original condition world_size > 1 incorrectly triggers write_shm in this case. This overhead scales with batch size, making it especially costly for large batches.

Fix: change the condition from world_size > 1 to num_tp_gpus > 1, so write_shm is only called when there are actual TP workers to consume it.After verification, the modification improves inference speed for the num_gpus=2, draft_async=True configuration, with especially notable improvements in large-batch scenarios.

