### PR TITLE
[Bug] prefix-cache-hit prefill reads wrong KV rows

### DIFF
--- a/ssd/layers/attention.py
+++ b/ssd/layers/attention.py
@@ -88,8 +88,7 @@ class Attention(nn.Module):
                 o = flash_attn_with_kvcache(q, k_cache, v_cache,
                                         cache_seqlens=cache_seqlens, page_table=context.block_tables,
                                         cu_seqlens_q=context.cu_seqlens_q, max_seqlen_q=context.max_seqlen_q,
-                                        softmax_scale=self.scale, causal=True,
-                                        )
+                                        softmax_scale=self.scale, causal=True)
             else:
                 o = flash_attn_varlen_func(q, k, v,
                                            max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,

--- a/ssd/layers/attention.py
+++ b/ssd/layers/attention.py
@@ -84,13 +84,17 @@ class Attention(nn.Module):
 
         if context.is_prefill:
             if context.block_tables is not None:
-                k, v = k_cache, v_cache
-
-            k, v = k.view(-1, self.num_kv_heads, self.head_dim), v.view(-1, self.num_kv_heads, self.head_dim)
-            o = flash_attn_varlen_func(q, k, v,
-                                       max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
-                                       max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
-                                       softmax_scale=self.scale, causal=True)
+                cache_seqlens = context.cu_seqlens_k[1:] - context.cu_seqlens_k[:-1]
+                o = flash_attn_with_kvcache(q, k_cache, v_cache,
+                                        cache_seqlens=cache_seqlens, page_table=context.block_tables,
+                                        softmax_scale=self.scale, causal=True,
+                                        cu_seqlens_q=context.cu_seqlens_q, max_seqlen_q=context.max_seqlen_q,
+                                        )
+            else:
+                o = flash_attn_varlen_func(q, k, v,
+                                           max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
+                                           max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
+                                           softmax_scale=self.scale, causal=True)
         else:
             # verify/glue decode: multi-query with cu_seqlens_q (K+1 or variable per seq)
             verify_or_glue = (

--- a/ssd/layers/attention.py
+++ b/ssd/layers/attention.py
@@ -87,8 +87,8 @@ class Attention(nn.Module):
                 cache_seqlens = context.cu_seqlens_k[1:] - context.cu_seqlens_k[:-1]
                 o = flash_attn_with_kvcache(q, k_cache, v_cache,
                                         cache_seqlens=cache_seqlens, page_table=context.block_tables,
-                                        softmax_scale=self.scale, causal=True,
                                         cu_seqlens_q=context.cu_seqlens_q, max_seqlen_q=context.max_seqlen_q,
+                                        softmax_scale=self.scale, causal=True,
                                         )
             else:
                 o = flash_attn_varlen_func(q, k, v,


### PR DESCRIPTION
fixes https://github.com/tanishqkumar/ssd/issues/23

# Problem
When a prefill batch contains a prefix-cache hit, the attention layer substitutes the entire per-layer paged K/V cache tensors for the fresh k/v tensors but does not pass the block table to the kernel. 
The kernel therefore treats the attention layer’s paged KV cache as contiguous memory and reads the wrong physical KV rows, silently producing incorrect outputs.

# Solution
use the function flash_attn_with_kvcache to pass block table to the attention kernel

# Evidence (Modal H100, Qwen3-0.6B)
Before (main branch):

<img width="976" height="635" alt="image" src="https://github.com/user-attachments/assets/2fceadd3-575c-45f5-b3d4-07d03e1b3f8b" />

After (this branch):

<img width="1000" height="617" alt="image" src="https://github.com/user-attachments/assets/7c1f828e-b5d7-44c0-9496-8933f7829aff" />

# reproduce script
https://github.com/tanishqkumar/ssd/pull/22#issuecomment-5126128102